### PR TITLE
DM-34691: Add few migrations for dimensions schema

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install
         run: pip install -r <(curl https://raw.githubusercontent.com/lsst/linting/main/requirements.txt)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.3.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python

--- a/migrations/dimensions-config/380002bcbb26.py
+++ b/migrations/dimensions-config/380002bcbb26.py
@@ -1,0 +1,70 @@
+"""Migration script for dimensions.yaml namespace=daf_butler version=1.
+
+Revision ID: 380002bcbb26
+Revises: f3bcee34f344
+Create Date: 2022-05-13 14:38:35.806960
+
+"""
+from typing import Callable, Dict
+
+from alembic import context
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+
+# revision identifiers, used by Alembic.
+revision = "380002bcbb26"
+down_revision = "f3bcee34f344"
+branch_labels = None
+depends_on = None
+
+# Change this when making a copy for different branch
+_NAMESPACE = "daf_butler"
+
+
+def upgrade() -> None:
+    """Upgrade from version 0 to version 1.
+
+    Version 1 adds few simple things to dimensions.json that do not modify
+    the schema:
+
+        - changes "version" value from 0 to 1
+        - adds "namespace" key to the configuration
+        - adds healpix to skypix
+
+    """
+
+    def update_config(config: Dict) -> Dict:
+        config["version"] = 1
+        config["namespace"] = _NAMESPACE
+        config["skypix"]["healpix"] = {
+            "class": "lsst.sphgeom.HealpixPixelization",
+            "max_level": 17,
+        }
+        return config
+
+    _migrate(update_config)
+
+
+def downgrade() -> None:
+    """Downgrade from version 1 to version 0, reverses changes made by
+    `upgrade`.
+    """
+
+    def update_config(config: Dict) -> Dict:
+        config["version"] = 0
+        del config["namespace"]
+        del config["skypix"]["healpix"]
+        return config
+
+    _migrate(update_config)
+
+
+def _migrate(update_config: Callable[[Dict], Dict]) -> None:
+
+    mig_context = context.get_context()
+
+    # When we use schemas in postgres then all tables belong to the same schema
+    # so we can use alembic's version_table_schema to see where everything goes
+    schema = mig_context.version_table_schema
+
+    attributes = ButlerAttributes(mig_context.bind, schema)
+    attributes.update_dimensions_json(update_config)

--- a/migrations/dimensions-config/3e2891b82110.py
+++ b/migrations/dimensions-config/3e2891b82110.py
@@ -1,0 +1,21 @@
+"""This is an initial pseudo-revision of the 'dimensions-config' tree.
+
+Revision ID: 3e2891b82110
+Revises:
+Create Date: 2022-05-13 14:37:42.026701
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "3e2891b82110"
+down_revision = None
+branch_labels = ("dimensions-config",)
+depends_on = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError("No upgrades for tree root")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("No downgrades for tree root")

--- a/migrations/dimensions-config/bf6308af80aa.py
+++ b/migrations/dimensions-config/bf6308af80aa.py
@@ -1,0 +1,413 @@
+"""Migration script for dimensions.yaml namespace=daf_butler version=2.
+
+Revision ID: bf6308af80aa
+Revises: 380002bcbb26
+Create Date: 2022-05-16 12:11:17.906600
+
+"""
+import logging
+from typing import Dict, List, Optional
+
+import sqlalchemy as sa
+from alembic import context, op
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+from lsst.daf.butler_migrate.digests import get_digest
+from lsst.daf.butler_migrate.shrink import shrinkDatabaseEntityName
+
+# revision identifiers, used by Alembic.
+revision = "bf6308af80aa"
+down_revision = "380002bcbb26"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Upgrade from version 1 to version 2.
+
+    Summary of changes:
+
+        - new table `visit_system_membership`
+        - new columns in dimension tables:
+            - instrument table adds visit_system column
+            - exposure table adds seq_start, seq_end, has_simulated, azimuth
+            - visit table adds seq_num and azimuth
+        - some of these new columns need to be populated with non-NULL values
+    """
+
+    config = context.config
+    has_simulated_str = config.get_section_option("daf_butler_migrate_options", "has_simulated")
+    if has_simulated_str is None:
+        raise ValueError(
+            "This migration script requires a default value be provided for the `has_simulated`"
+            " field in the `exposure` record. Please use `--options has_simulated=1` or"
+            " `--options has_simulated=0` command line option."
+        )
+    if has_simulated_str == "0":
+        has_simulated = False
+    elif has_simulated_str == "1":
+        has_simulated = True
+    else:
+        raise ValueError(f"Unexpected value of `has_simulated` option: {has_simulated_str}")
+
+    _migrate_instrument()
+    _migrate_visit()
+    _migrate_exposure(has_simulated)
+    _migrate_visit_definition()
+    _migrate_dimensions_json()
+    _migrate_schema_digest()
+
+
+def downgrade() -> None:
+    """Downgrade is not implemented, it may be relatively easy to do but it is
+    likely we never need it.
+    """
+    raise NotImplementedError()
+
+
+def _FKConstraint(
+    src_table: str,
+    src_columns: List[str],
+    tgt_table: str,
+    tgt_columns: List[str],
+    bind: sa.engine.Connection,
+    schema: Optional[str] = None,
+    ondelete: Optional[str] = None,
+) -> sa.schema.ForeignKeyConstraint:
+    """Create foreign key constraint."""
+    fk_name = "_".join(["fkey", src_table, tgt_table] + tgt_columns + src_columns)
+    fk_name = shrinkDatabaseEntityName(fk_name, bind)
+    tgt_columns = [f"{tgt_table}.{col}" for col in tgt_columns]
+    if schema:
+        tgt_columns = [f"{schema}.{col}" for col in tgt_columns]
+    return sa.schema.ForeignKeyConstraint(src_columns, tgt_columns, name=fk_name, ondelete=ondelete)
+
+
+def _migrate_visit_definition() -> None:
+    """Make new visit_system_membership table, fill from existing data
+    in visit_definition."""
+
+    mig_context = context.get_context()
+    bind = mig_context.bind
+    schema = mig_context.version_table_schema
+    metadata = sa.schema.MetaData(bind, schema=schema)
+
+    table = "visit_system_membership"
+    _LOG.info("creating %s table", table)
+    constraints = [
+        _FKConstraint(table, ["instrument"], "instrument", ["name"], bind, schema=schema),
+        _FKConstraint(
+            table, ["instrument", "visit_system"], "visit_system", ["instrument", "id"], bind, schema=schema
+        ),
+        _FKConstraint(table, ["instrument", "visit"], "visit", ["instrument", "id"], bind, schema=schema),
+    ]
+    if bind.dialect.name == "sqlite":
+        constraints.append(
+            sa.schema.CheckConstraint(
+                "length(instrument)<=16 AND length(instrument)>=1",
+                name=shrinkDatabaseEntityName("_".join([table, "len", "instrument"]), bind),
+            )
+        )
+    visit_membership = op.create_table(
+        table,
+        sa.Column("instrument", sa.String(16), primary_key=True, autoincrement=False),
+        sa.Column("visit_system", sa.BigInteger, primary_key=True, autoincrement=False),
+        sa.Column("visit", sa.BigInteger, primary_key=True, autoincrement=False),
+        *constraints,
+        schema=schema,
+    )
+
+    op.create_index(
+        shrinkDatabaseEntityName("_".join([table, "fkidx", "instrument", "visit_system"]), bind),
+        table,
+        ["instrument", "visit_system"],
+        schema=schema,
+    )
+    op.create_index(
+        shrinkDatabaseEntityName("_".join([table, "fkidx", "instrument", "visit"]), bind),
+        table,
+        ["instrument", "visit"],
+        schema=schema,
+    )
+    op.create_index(
+        shrinkDatabaseEntityName("_".join([table, "fkidx", "instrument"]), bind),
+        table,
+        ["instrument"],
+        schema=schema,
+    )
+
+    visit_definition = sa.schema.Table("visit_definition", metadata, autoload_with=bind, schema=schema)
+
+    # Copy everything from visit_definition to the new table.
+    selection = sa.select(
+        visit_definition.columns["instrument"],
+        visit_definition.columns["visit_system"],
+        visit_definition.columns["visit"],
+    ).distinct()
+    sql = visit_membership.insert().from_select(["instrument", "visit_system", "visit"], selection)
+    op.execute(sql)
+
+    # Drop visit_system from visit_definition.
+    with op.batch_alter_table("visit_definition", schema=schema) as batch_op:
+        # visit_system is in PK. Postgres drops PK when the column is dropped,
+        # but sqlite complains that column cannot be dropped if it's in PK.
+        # The workaround is to create PK with new columns, but Postgres also
+        # requires existing PK to be dropped first, and in sqlite we do not
+        # even have name for PK constraint, so it cannot be dropped
+        # explicitly.
+        if bind.dialect.name == "postgresql":
+            batch_op.drop_constraint("visit_definition_pkey")
+        batch_op.create_primary_key("visit_definition_pkey", ["instrument", "exposure", "visit"])
+        batch_op.drop_index("visit_definition_fkidx_instrument_visit_system")
+        batch_op.drop_column("visit_system")
+
+
+def _migrate_instrument() -> None:
+    """Add and populate visit_system column in instrument table."""
+    mig_context = context.get_context()
+    bind = mig_context.bind
+    schema = mig_context.version_table_schema
+    metadata = sa.schema.MetaData(bind, schema=schema)
+
+    _LOG.info("Migrating instrument table")
+    op.add_column(
+        "instrument",
+        sa.Column("visit_system", sa.BigInteger),
+        schema=schema,
+    )
+
+    table = sa.schema.Table("instrument", metadata, autoload_with=bind, schema=schema)
+
+    op.execute(table.update().values(visit_system=0))
+    op.execute(
+        table.update()
+        .where(table.columns["name"].in_(["LSSTCam", "LATISS", "LSSTComCam"]))
+        .values(visit_system=2)
+    )
+
+
+def _migrate_visit() -> None:
+    """Drop visit_system column from visit table and add seq_num and azimuth
+    columns to visit. The seq_num column is populated from the minimum seq_num
+    value of the matching exposures.
+    """
+    mig_context = context.get_context()
+    bind = mig_context.bind
+    schema = mig_context.version_table_schema
+    metadata = sa.schema.MetaData(bind, schema=schema)
+
+    _LOG.info("migrating visit table")
+    with op.batch_alter_table("visit", schema=schema) as batch_op:
+        batch_op.drop_index("visit_fkidx_instrument_visit_system")
+        batch_op.drop_column("visit_system")
+        batch_op.add_column(sa.Column("seq_num", sa.BigInteger))
+        batch_op.add_column(sa.Column("azimuth", sa.Float))
+
+    # Fill seq_num column with the lowest value of matching exposure.seq_num.
+    #
+    # Query for correlated update:
+    #
+    # UPDATE
+    #     visit
+    # SET
+    #     seq_num = (
+    #         SELECT
+    #             MIN(exposure.seq_num)
+    #         FROM
+    #             exposure
+    #             JOIN visit_definition ON visit_definition.exposure = exposure.id
+    #             and visit_definition.instrument = exposure.instrument
+    #         WHERE
+    #             visit_definition.instrument = visit.instrument,
+    #             visit_definition.visit = visit.id
+    #     )
+
+    visit = sa.schema.Table("visit", metadata, autoload_with=bind, schema=schema)
+    exposure = sa.schema.Table("exposure", metadata, autoload_with=bind, schema=schema)
+    visit_def = sa.schema.Table("visit_definition", metadata, autoload_with=bind, schema=schema)
+
+    min_seq = (
+        sa.select(sa.sql.functions.min(exposure.columns["seq_num"]))
+        .select_from(exposure.join(visit_def))
+        .where(
+            sa.sql.expression.and_(
+                visit_def.columns["instrument"] == visit.columns["instrument"],
+                visit_def.columns["visit"] == visit.columns["id"],
+            )
+        )
+    )
+    sql = visit.update().values(seq_num=min_seq.scalar_subquery())
+    op.execute(sql)
+
+
+def _migrate_exposure(has_simulated: bool) -> None:
+    """Update exposure table.
+
+    Parameters
+    ----------
+    has_simulated : `bool`
+        Value for the new ``has_simulated`` column.
+    """
+    mig_context = context.get_context()
+    bind = mig_context.bind
+    schema = mig_context.version_table_schema
+    metadata = sa.schema.MetaData(bind, schema=schema)
+
+    _LOG.info("migrating exposure table")
+    with op.batch_alter_table("exposure", schema=schema) as batch_op:
+        batch_op.add_column(sa.Column("seq_start", sa.BigInteger))
+        batch_op.add_column(sa.Column("seq_end", sa.BigInteger))
+        batch_op.add_column(sa.Column("azimuth", sa.Float))
+        batch_op.add_column(sa.Column("has_simulated", sa.Boolean))
+
+    table = sa.schema.Table("exposure", metadata, autoload_with=bind, schema=schema)
+    op.execute(
+        table.update().values(
+            seq_start=table.columns["seq_num"], seq_end=table.columns["seq_num"], has_simulated=has_simulated
+        )
+    )
+
+
+def _migrate_dimensions_json() -> None:
+    """Updates dimensions definitions in dimensions.json."""
+
+    mig_context = context.get_context()
+    schema = mig_context.version_table_schema
+    attributes = ButlerAttributes(mig_context.bind, schema)
+
+    def update_config(config: Dict) -> Dict:
+
+        config["version"] = 2
+
+        instrument = config["elements"]["instrument"]
+        instrument["metadata"].insert(
+            1,
+            {"name": "visit_system", "type": "int", "doc": "The preferred visit system for this instrument."},
+        )
+
+        visit = config["elements"]["visit"]
+        visit["implies"].remove("visit_system")
+        visit["metadata"].insert(
+            1,
+            {
+                "name": "seq_num",
+                "type": "int",
+                "doc": "The sequence number of the first exposure that is part of this visit.",
+            },
+        )
+        visit["metadata"].insert(
+            -1,
+            {
+                "name": "azimuth",
+                "type": "float",
+                "doc": (
+                    "Approximate azimuth of the telescope in degrees during the visit. "
+                    "Can only be approximate since it is continually changing during "
+                    "an observation and multiple exposures can be combined from a "
+                    "relatively long period."
+                ),
+            },
+        )
+
+        exposure = config["elements"]["exposure"]
+        exposure["metadata"].insert(
+            6,
+            {
+                "name": "seq_start",
+                "type": "int",
+                "doc": "The sequence number of the first exposure of the visit that contains this exposure.",
+            },
+        )
+        exposure["metadata"].insert(
+            7,
+            {
+                "name": "seq_end",
+                "type": "int",
+                "doc": "The sequence number of the final exposure of the visit that contains this exposure.",
+            },
+        )
+        exposure["metadata"].insert(
+            -1,
+            {
+                "name": "azimuth",
+                "type": "float",
+                "doc": (
+                    "Azimuth of the telescope at the start of the exposure in degrees. "
+                    "Can be NULL for observations that are not on sky, or for observations "
+                    "where the azimuth is not relevant."
+                ),
+            },
+        )
+        exposure["metadata"].append(
+            {
+                "name": "has_simulated",
+                "type": "bool",
+                "doc": (
+                    "True if this exposure has some content that was simulated. "
+                    "This can be if the data itself were simulated or if "
+                    "parts of the header came from simulated systems, such as observations "
+                    "in the lab that are recorded as on-sky."
+                ),
+            },
+        )
+
+        visit_system = config["elements"]["visit_system"]
+        visit_system["doc"] = (
+            "A system of self-consistent visit definitions, within which each "
+            "exposure should appear at most once.\n"
+            "A visit may belong to multiple visit systems, if the logical definitions "
+            "for those systems happen to result in the same set of exposures - the "
+            "main (and probably only) example is when a single-snap visit is observed, "
+            'for which both the "one-to-one" visit system and a "group by header metadata" visit '
+            "system will define the same single-exposure visit. "
+        )
+
+        visit_definition = config["elements"]["visit_definition"]
+        visit_definition["requires"].remove("visit_system")
+        visit_definition["requires"].append("visit")
+        del visit_definition["implies"]
+
+        config["elements"]["visit_system_membership"] = {
+            "doc": "A many-to-many join table that relates visits to the visit_systems they belong to.",
+            "requires": ["visit", "visit_system"],
+            "always_join": True,
+            "storage": {"cls": "lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage"},
+        }
+
+        return config
+
+    _LOG.info("migrating stored dimesions.json")
+    attributes.update_dimensions_json(update_config)
+
+
+def _migrate_schema_digest():
+    """Update schema digest for dimension record tables.
+
+    Note that that new releases, right before dimensions manager version
+    6.0.2, stopped validating digests. We want to keep older releases happy
+    though, so this digest actually corresponds to dimensions manager 6.0.1
+    with updated dimensions configuration.
+    """
+
+    mig_context = context.get_context()
+    bind = mig_context.bind
+    if bind.dialect.name == "postgresql":
+        digest = "689da2cd495d8caba0eb05cb137c177f"
+    elif bind.dialect.name == "sqlite":
+        digest = "67be8681bc44dd8ed717b9056679f62c"
+    else:
+        return
+
+    schema = mig_context.version_table_schema
+    attributes = ButlerAttributes(mig_context.bind, schema)
+
+    manager_class = attributes.get("config:registry.managers.dimensions")
+    assert manager_class.endswith(
+        "StaticDimensionRecordStorageManager"
+    ), f"Unexpected class name of dimensions manager {manager_class}"
+
+    _LOG.info("migrating dimensions schema digest")
+
+    count = attributes.update(f"schema_digest:{manager_class}", digest)
+    assert count == 1, "expected to update single row"

--- a/migrations/dimensions-config/f3bcee34f344.py
+++ b/migrations/dimensions-config/f3bcee34f344.py
@@ -1,0 +1,21 @@
+"""Migration script for dimensions.yaml namespace=daf_butler version=0.
+
+Revision ID: f3bcee34f344
+Revises: 3e2891b82110
+Create Date: 2022-05-13 14:38:32.175603
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f3bcee34f344"
+down_revision = "3e2891b82110"
+branch_labels = ("dimensions-config-daf_butler",)
+depends_on = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError("Version 0 can only be created by daf_butler")
+
+
+def downgrade() -> None:
+    raise NotImplementedError()

--- a/migrations/dimensions/035dcf13ef18.py
+++ b/migrations/dimensions/035dcf13ef18.py
@@ -1,0 +1,87 @@
+"""Migration script for StaticDimensionRecordStorageManager 6.0.2.
+
+Revision ID: 035dcf13ef18
+Revises: 1601d5973bf8
+Create Date: 2022-05-19 15:40:18.561744
+
+"""
+import logging
+
+import sqlalchemy as sa
+from alembic import context, op
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+from lsst.daf.butler_migrate.digests import get_digest
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision = "035dcf13ef18"
+down_revision = "1601d5973bf8"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+# Manager name
+MANAGER = "lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager"
+
+
+def upgrade() -> None:
+    """Summary of changes for this migration:
+
+        - implied dimension columns (non-PK foreign keys) add NOT NULL
+
+    Note that schema digests are not updated. Just before we updated code for
+    6.0.2 versions we disabled validation of checksums. Older code that uses
+    6.0.1 is still validating checksums so we keep checksum from 6.0.1 in the
+    database.
+    """
+    _do_migration(nullable=False, manager_version="6.0.2")
+
+
+def downgrade() -> None:
+    """Reverses the effect of `upgrade`."""
+    _do_migration(nullable=True, manager_version="6.0.1")
+
+
+def _do_migration(nullable: bool, manager_version: str) -> None:
+    """Run the whole migration.
+
+    Parameters
+    ----------
+    nullable : `bool`
+        False if columns are to be made NOT NULL, True if they are to be made
+        NULL.
+    manager_version : `str`
+        Manager version to store in butler_attributes.
+    """
+    mig_context = context.get_context()
+    bind = mig_context.bind
+    schema = mig_context.version_table_schema
+
+    inspector = Inspector.from_engine(bind)
+    attributes = ButlerAttributes(bind, schema)
+
+    # To know dimension record tables and their implied columns we need to look
+    # at dimensions config.
+    config = attributes.get_dimensions_json()
+    for element_name, element_config in config["elements"].items():
+        if (implied := element_config.get("implies")) is not None:
+
+            # some elements do not have tables
+            if not inspector.has_table(element_name, schema=schema):
+                continue
+
+            # Do it in batch in case someone wants to run it on SQLite
+            with op.batch_alter_table(element_name, schema=schema) as batch_op:
+                for other_element in implied:
+                    # Referenced table need to exists
+                    if not inspector.has_table(other_element, schema=schema):
+                        continue
+                    if nullable:
+                        _LOG.info("Add NULL to column %s.%s", element_name, other_element)
+                    else:
+                        _LOG.info("Add NOT NULL to column %s.%s", element_name, other_element)
+                    batch_op.alter_column(other_element, nullable=nullable)
+
+    count = attributes.update(f"version:{MANAGER}", manager_version)
+    assert count == 1, "expected to update single row"

--- a/python/lsst/daf/butler_migrate/butler_attributes.py
+++ b/python/lsst/daf/butler_migrate/butler_attributes.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import Callable, Dict, Optional
 
 import sqlalchemy
 
@@ -44,6 +45,24 @@ class ButlerAttributes:
             "butler_attributes", metadata, autoload_with=connection, schema=schema
         )
 
+    def get(self, name: str) -> Optional[str]:
+        """Retrieve values of the named attribute.
+
+        Parameters
+        ----------
+        name : `str`
+            Attribute name.
+
+        Returns
+        -------
+        value : `str` or `None`
+            Attribute value, `None` is returned if attribute does not exist.
+        """
+        sql = sqlalchemy.select(self._table.columns["value"]).where(self._table.columns["name"] == name)
+        result = self._connection.execute(sql)
+        row = result.fetchone()
+        return row[0] if row is not None else None
+
     def update(self, name: str, value: str) -> int:
         """Update the value of existing parameter in butler_attributes table.
 
@@ -63,3 +82,24 @@ class ButlerAttributes:
         # update version
         sql = self._table.update().where(self._table.columns.name == name).values(value=value)
         return self._connection.execute(sql).rowcount
+
+    def update_dimensions_json(self, update_config: Callable[[Dict], Dict]) -> None:
+        """Updates dimensions definitions in dimensions.json.
+
+        Parameters
+        ----------
+        update_config : `Callable`
+            A method that takes a dictionary representation of the
+            ``dimensions.json`` and returns an updated dictionary.
+        """
+        key = "config:dimensions.json"
+        config_json = self.get(key)
+        if config_json is None:
+            raise LookupError(f"Key {key} does not exist in attributes table")
+        config = json.loads(config_json)
+
+        # modify config
+        config = update_config(config)
+
+        config_json = json.dumps(config)
+        self.update(key, config_json)

--- a/python/lsst/daf/butler_migrate/butler_attributes.py
+++ b/python/lsst/daf/butler_migrate/butler_attributes.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 import json
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import sqlalchemy
 
@@ -82,6 +82,21 @@ class ButlerAttributes:
         # update version
         sql = self._table.update().where(self._table.columns.name == name).values(value=value)
         return self._connection.execute(sql).rowcount
+
+    def get_dimensions_json(self) -> Dict[str, Any]:
+        """Return dimensions configuration from dimensions.json.
+
+        Returns
+        -------
+        config : `dict`
+            Contents of ``dimensions.json`` as dictionary.
+        """
+        key = "config:dimensions.json"
+        config_json = self.get(key)
+        if config_json is None:
+            raise LookupError(f"Key {key} does not exist in attributes table")
+        config = json.loads(config_json)
+        return config
 
     def update_dimensions_json(self, update_config: Callable[[Dict], Dict]) -> None:
         """Updates dimensions definitions in dimensions.json.

--- a/python/lsst/daf/butler_migrate/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_migrate/cli/cmd/commands.py
@@ -32,6 +32,7 @@ from ..opt import (
     manager_argument,
     mig_path_exist_option,
     mig_path_option,
+    namespace_argument,
     namespace_option,
     one_shot_option,
     one_shot_tree_option,
@@ -39,6 +40,7 @@ from ..opt import (
     revision_argument,
     sql_option,
     tree_name_argument,
+    update_namespace_option,
     verbose_option,
     version_argument,
 )
@@ -147,3 +149,14 @@ def rewrite_sqlite_registry(**kwargs: Any) -> None:
     old registry moved to a backup file.
     """
     script.rewrite_sqlite_registry(**kwargs)
+
+
+@migrate.command(
+    short_help="Add namespace attribute to the stored dimensions configuration.", cls=ButlerCommand
+)
+@update_namespace_option
+@repo_argument(required=True)
+@namespace_argument(required=False)
+def set_namespace(**kwargs: Any) -> None:
+    """Add or update namespace attribute to dimensions.json"""
+    script.migrate_set_namespace(**kwargs)

--- a/python/lsst/daf/butler_migrate/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_migrate/cli/cmd/commands.py
@@ -29,8 +29,10 @@ from ... import script
 from ..opt import (
     class_argument,
     dry_run_option,
+    manager_argument,
     mig_path_exist_option,
     mig_path_option,
+    namespace_option,
     one_shot_option,
     one_shot_tree_option,
     purge_option,
@@ -90,8 +92,10 @@ def show_trees(*args: Any, **kwargs: Any) -> None:
 @migrate.command(short_help="Stamp revision table with current registry versions.", cls=ButlerCommand)
 @mig_path_exist_option
 @purge_option
+@namespace_option
 @dry_run_option
 @repo_argument(required=True)
+@manager_argument()
 def stamp(*args: Any, **kwargs: Any) -> None:
     """Stamp revision table with current registry versions."""
     script.migrate_stamp(*args, **kwargs)
@@ -100,6 +104,7 @@ def stamp(*args: Any, **kwargs: Any) -> None:
 @migrate.command(short_help="Display current revisions for a database.", cls=ButlerCommand)
 @verbose_option
 @click.option("--butler", help="Display butler version numbers for managers.", is_flag=True)
+@namespace_option
 @mig_path_exist_option
 @repo_argument(required=True)
 def show_current(*args: Any, **kwargs: Any) -> None:
@@ -111,6 +116,7 @@ def show_current(*args: Any, **kwargs: Any) -> None:
 @mig_path_exist_option
 @one_shot_tree_option
 @sql_option
+@namespace_option
 @repo_argument(required=True)
 @revision_argument(required=True)
 def upgrade(*args: Any, **kwargs: Any) -> None:
@@ -122,6 +128,7 @@ def upgrade(*args: Any, **kwargs: Any) -> None:
 @mig_path_exist_option
 @one_shot_tree_option
 @sql_option
+@namespace_option
 @repo_argument(required=True)
 @revision_argument(required=True)
 def downgrade(*args: Any, **kwargs: Any) -> None:
@@ -131,7 +138,7 @@ def downgrade(*args: Any, **kwargs: Any) -> None:
 
 @migrate.command(short_help="Upgrade a SQLite registry by rewriting it from scratch.", cls=ButlerCommand)
 @click.argument("source", required=True)
-def rewrite_sqlite_registry(**kwargs):
+def rewrite_sqlite_registry(**kwargs: Any) -> None:
     """Transfer registry information from one registry to a new registry.
 
     SOURCE is a URI to the Butler repository to be transferred.

--- a/python/lsst/daf/butler_migrate/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_migrate/cli/cmd/commands.py
@@ -36,6 +36,7 @@ from ..opt import (
     namespace_option,
     one_shot_option,
     one_shot_tree_option,
+    options_option,
     purge_option,
     revision_argument,
     sql_option,
@@ -119,6 +120,7 @@ def show_current(*args: Any, **kwargs: Any) -> None:
 @one_shot_tree_option
 @sql_option
 @namespace_option
+@options_option
 @repo_argument(required=True)
 @revision_argument(required=True)
 def upgrade(*args: Any, **kwargs: Any) -> None:

--- a/python/lsst/daf/butler_migrate/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_migrate/cli/cmd/commands.py
@@ -40,6 +40,7 @@ from ..opt import (
     purge_option,
     revision_argument,
     sql_option,
+    tables_argument,
     tree_name_argument,
     update_namespace_option,
     verbose_option,
@@ -162,3 +163,11 @@ def rewrite_sqlite_registry(**kwargs: Any) -> None:
 def set_namespace(**kwargs: Any) -> None:
     """Add or update namespace attribute to dimensions.json"""
     script.migrate_set_namespace(**kwargs)
+
+
+@migrate.command(short_help="Dump schema of the database tables.", cls=ButlerCommand)
+@repo_argument(required=True)
+@tables_argument(required=False)
+def dump_schema(**kwargs: Any) -> None:
+    """Add or update namespace attribute to dimensions.json"""
+    script.migrate_dump_schema(**kwargs)

--- a/python/lsst/daf/butler_migrate/cli/opt/arguments.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/arguments.py
@@ -55,3 +55,12 @@ manager_argument = MWArgumentDecorator(
     ),
     required=False,
 )
+
+namespace_argument = MWArgumentDecorator(
+    "namespace",
+    help=(
+        "NAMESPACE to add or replace in the stored dimensions configuration. "
+        "If namespace is not specified then existing namespace is printed."
+    ),
+    required=False,
+)

--- a/python/lsst/daf/butler_migrate/cli/opt/arguments.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/arguments.py
@@ -64,3 +64,11 @@ namespace_argument = MWArgumentDecorator(
     ),
     required=False,
 )
+
+
+tables_argument = MWArgumentDecorator(
+    "table",
+    help="TABLE specify multiple optional table names to dump, by default all tables are dumped.",
+    required=False,
+    nargs=-1,
+)

--- a/python/lsst/daf/butler_migrate/cli/opt/arguments.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/arguments.py
@@ -46,3 +46,12 @@ revision_argument = MWArgumentDecorator(
         "specify initial revision using INITIAL:TARGET format."
     ),
 )
+
+manager_argument = MWArgumentDecorator(
+    "manager",
+    help=(
+        "MANAGER is a name of the manager for which to stamp the revision, "
+        "if missing then all managers are stamped."
+    ),
+    required=False,
+)

--- a/python/lsst/daf/butler_migrate/cli/opt/options.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/options.py
@@ -58,3 +58,9 @@ purge_option = click.option(
 sql_option = click.option(
     "--sql", help="Offline mode, dump SQL instead of executing migration on a database.", is_flag=True
 )
+
+namespace_option = click.option(
+    "--namespace",
+    help="Namespace to use when 'namespace' key is not present in the stored dimesions configuration",
+    default=None,
+)

--- a/python/lsst/daf/butler_migrate/cli/opt/options.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/options.py
@@ -61,6 +61,6 @@ sql_option = click.option(
 
 namespace_option = click.option(
     "--namespace",
-    help="Namespace to use when 'namespace' key is not present in the stored dimesions configuration",
+    help="Namespace to use when 'namespace' key is not present in the stored dimensions configuration",
     default=None,
 )

--- a/python/lsst/daf/butler_migrate/cli/opt/options.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/options.py
@@ -64,3 +64,7 @@ namespace_option = click.option(
     help="Namespace to use when 'namespace' key is not present in the stored dimensions configuration",
     default=None,
 )
+
+update_namespace_option = click.option(
+    "--update", help="Replace existing namespace if it exists.", is_flag=True
+)

--- a/python/lsst/daf/butler_migrate/cli/opt/options.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/options.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import click
+from lsst.daf.butler.cli.utils import split_kv
 
 from ... import migrate
 
@@ -67,4 +68,12 @@ namespace_option = click.option(
 
 update_namespace_option = click.option(
     "--update", help="Replace existing namespace if it exists.", is_flag=True
+)
+
+options_option = click.option(
+    "--options",
+    callback=split_kv,
+    help="Options to pass to migration scripts, as a key-value pair.",
+    metavar="TEXT=TEXT",
+    multiple=True,
 )

--- a/python/lsst/daf/butler_migrate/config.py
+++ b/python/lsst/daf/butler_migrate/config.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from alembic.config import Config
 
@@ -45,6 +45,7 @@ class MigAlembicConfig(Config):
         db: Optional[database.Database] = None,
         single_tree: Optional[str] = None,
         one_shot_tree: Optional[str] = None,
+        migration_options: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> MigAlembicConfig:
         """Create new configuration object.
@@ -63,6 +64,9 @@ class MigAlembicConfig(Config):
             If this is given (and ``single_tree`` is not) then this tree will
             replace regular version tree for corresponding manager. Tree name
             must contain slash character separating manager name and tree name.
+        migration_options : `dict`, optional
+            Additional options that can be passed to migration script via the
+            configuration object, in a section "daf_butler_migrate_options".
         """
         alembic_folder = os.path.join(mig_path, "_alembic")
         ini_path = os.path.join(alembic_folder, "alembic.ini")
@@ -94,11 +98,16 @@ class MigAlembicConfig(Config):
         # we do not use this option, this is just to make sure that
         # [daf_butler_migrate] section exists
         cfg.set_section_option("daf_butler_migrate", "_daf_butler_migrate", "")
+        cfg.set_section_option("daf_butler_migrate_options", "_daf_butler_migrate_options", "")
 
         if db is not None:
             cfg.set_main_option("sqlalchemy.url", db.db_url)
             if db.schema:
                 cfg.set_section_option("daf_butler_migrate", "schema", db.schema)
+
+        if migration_options:
+            for key, value in migration_options.items():
+                cfg.set_section_option("daf_butler_migrate_options", key, value)
 
         return cfg
 

--- a/python/lsst/daf/butler_migrate/database.py
+++ b/python/lsst/daf/butler_migrate/database.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Dict, List, Mapping, Optional, Tuple
+from contextlib import contextmanager
+from typing import Dict, Iterator, List, Mapping, Optional, Tuple
 
 import sqlalchemy
 from alembic.runtime.migration import MigrationContext
@@ -96,6 +97,13 @@ class Database:
     def schema(self) -> Optional[str]:
         """Schema (namespace) name (`str`)"""
         return self._schema
+
+    @contextmanager
+    def connect(self) -> Iterator[sqlalchemy.engine.Connection]:
+        """Context manager for database connection."""
+        engine = sqlalchemy.engine.create_engine(self._db_url)
+        with engine.connect() as connection:
+            yield connection
 
     def dimensions_namespace(self) -> Optional[str]:
         """Return dimensions namespace from a stored configuration.

--- a/python/lsst/daf/butler_migrate/script/__init__.py
+++ b/python/lsst/daf/butler_migrate/script/__init__.py
@@ -24,6 +24,7 @@ from .migrate_current import migrate_current
 from .migrate_downgrade import migrate_downgrade
 from .migrate_history import migrate_history
 from .migrate_revision import migrate_revision
+from .migrate_set_namespace import migrate_set_namespace
 from .migrate_stamp import migrate_stamp
 from .migrate_trees import migrate_trees
 from .migrate_upgrade import migrate_upgrade

--- a/python/lsst/daf/butler_migrate/script/migrate_downgrade.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_downgrade.py
@@ -34,7 +34,9 @@ from .. import config, database
 _LOG = logging.getLogger(__name__)
 
 
-def migrate_downgrade(repo: str, revision: str, mig_path: str, one_shot_tree: str, sql: bool) -> None:
+def migrate_downgrade(
+    repo: str, revision: str, mig_path: str, one_shot_tree: str, sql: bool, namespace: Optional[str]
+) -> None:
     """Downgrade schema to a specified revision.
 
     Parameters
@@ -50,8 +52,17 @@ def migrate_downgrade(repo: str, revision: str, mig_path: str, one_shot_tree: st
         Nфme of special one-shot tree, if empty use regular history.
     sql : `bool`
         If True dump SQL instead of executing migration on a database.
+    namespace: `str`, optional
+        Dimensions namespace to use when "namespace" key is not present in
+        ``config:dimensions.json``.
     """
     db = database.Database.from_repo(repo)
+
+    if namespace is None and db.dimensions_namespace() is None:
+        raise ValueError(
+            "The `--namespace` option is required when namespace is missing from"
+            " stored dimensions configuration"
+        )
 
     # Check that alembic versions exist in database, we do not support
     # migrations from empty state.
@@ -61,7 +72,7 @@ def migrate_downgrade(repo: str, revision: str, mig_path: str, one_shot_tree: st
         )
 
     # check that alembic versions are consistent with butler
-    db.validate_revisions()
+    db.validate_revisions(namespace)
 
     one_shot_arg: Optional[str] = None
     if one_shot_tree:

--- a/python/lsst/daf/butler_migrate/script/migrate_dump_schema.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_dump_schema.py
@@ -1,8 +1,8 @@
-# This file is part of obs_base.
+# This file is part of daf_butler_migrate.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project
-# (https://www.lsst.org).
+# (http://www.lsst.org).
 # See the COPYRIGHT file at the top-level directory of this distribution
 # for details of code ownership.
 #
@@ -17,16 +17,28 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .migrate_add_tree import migrate_add_tree
-from .migrate_current import migrate_current
-from .migrate_downgrade import migrate_downgrade
-from .migrate_dump_schema import migrate_dump_schema
-from .migrate_history import migrate_history
-from .migrate_revision import migrate_revision
-from .migrate_set_namespace import migrate_set_namespace
-from .migrate_stamp import migrate_stamp
-from .migrate_trees import migrate_trees
-from .migrate_upgrade import migrate_upgrade
-from .rewrite_sqlite_registry import rewrite_sqlite_registry
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from .. import database
+
+_LOG = logging.getLogger(__name__)
+
+
+def migrate_dump_schema(repo: str, table: List[str]) -> None:
+    """Dump the schema of the registry database.
+
+    Parameters
+    ----------
+    repo : `str`
+        Path to butler configuration YAML file or a directory containing a
+        "butler.yaml" file.
+    tables: `list`
+        List of the tables, if empty then schema for all tables is printed.
+    """
+    db = database.Database.from_repo(repo)
+    db.dump_schema(table)

--- a/python/lsst/daf/butler_migrate/script/migrate_set_namespace.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_set_namespace.py
@@ -1,0 +1,74 @@
+# This file is part of daf_butler_migrate.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Display current revisions for a database.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+from .. import butler_attributes, database
+
+_LOG = logging.getLogger(__name__)
+
+
+def migrate_set_namespace(repo: str, namespace: Optional[str], update: bool) -> None:
+    """Display current revisions for a database.
+
+    Parameters
+    ----------
+    repo : `str`
+        Path to butler configuration YAML file or a directory containing a
+        "butler.yaml" file.
+    namespace: `str`, optional
+        Dimensions namespace to set, if `None` then existing namespace is
+        printed.
+    update : `bool`
+        Allows update of the existing namespace.
+    """
+    db = database.Database.from_repo(repo)
+    db_namespace = db.dimensions_namespace()
+
+    if not namespace:
+
+        # Print current value
+        if not db_namespace:
+            print("No namespace defined in dimensions configuration.")
+        else:
+            print("Current dimensions namespace:", db_namespace)
+
+    else:
+
+        if db_namespace and not update:
+            raise ValueError(
+                f"Namespace is already defined ({db_namespace}), use --update option to replace it."
+            )
+
+        def update_namespace(config: Dict) -> Dict:
+            """Update namespace attribute"""
+            config["namespace"] = namespace
+            return config
+
+        with db.connect() as connection:
+            attributes = butler_attributes.ButlerAttributes(connection, db.schema)
+            attributes.update_dimensions_json(update_namespace)

--- a/python/lsst/daf/butler_migrate/script/migrate_upgrade.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_upgrade.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 from alembic import command
 
@@ -35,7 +35,13 @@ _LOG = logging.getLogger(__name__)
 
 
 def migrate_upgrade(
-    repo: str, revision: str, mig_path: str, one_shot_tree: str, sql: bool, namespace: Optional[str]
+    repo: str,
+    revision: str,
+    mig_path: str,
+    one_shot_tree: str,
+    sql: bool,
+    namespace: Optional[str],
+    options: Optional[Dict[str, str]],
 ) -> None:
     """Upgrade schema to a specified revision.
 
@@ -77,6 +83,8 @@ def migrate_upgrade(
     one_shot_arg: Optional[str] = None
     if one_shot_tree:
         one_shot_arg = one_shot_tree
-    cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db, one_shot_tree=one_shot_arg)
+    cfg = config.MigAlembicConfig.from_mig_path(
+        mig_path, db=db, one_shot_tree=one_shot_arg, migration_options=options
+    )
 
     command.upgrade(cfg, revision, sql=sql)

--- a/templates/generic/script.py.mako
+++ b/templates/generic/script.py.mako
@@ -5,8 +5,8 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/tests/config/dimensions-v0.yaml
+++ b/tests/config/dimensions-v0.yaml
@@ -1,0 +1,440 @@
+version: 0
+skypix:
+  # 'common' is the skypix system and level used to relate all other spatial
+  # dimensions.  Its value is a string formed by concatenating one of the
+  # other keys under the 'skypix' headerin (i.e. the name of a skypix system)
+  # with an integer level (with no zero-padding).
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
+
+elements:
+  instrument:
+    doc: >
+      An entity that produces observations.  An instrument defines a set of
+      physical_filters and detectors and a numbering system for the exposures
+      and visits that represent observations with it.
+    keys:
+      -
+        name: name
+        type: string
+        length: 16
+    metadata:
+      -
+        name: visit_max
+        type: int
+        doc: >
+          Maximum value for the 'visit' field for visits associated with
+          this instrument (exclusive).
+      -
+        name: exposure_max
+        type: int
+        doc: >
+          Maximum value for the 'exposure' field for exposures associated with
+          this instrument (exclusive).
+      -
+        name: detector_max
+        type: int
+        doc: >
+          Maximum value for the 'detector' field for detectors associated with
+          this instrument (exclusive).
+      -
+        name: class_name
+        type: string
+        length: 64
+        doc: >
+          Full class name of the Instrument class associated with this
+          instrument.
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  band:
+    doc: >
+      A filter that is not associated with a particular instrument.  An
+      abstract filter can be used to relate similar physical filters, and
+      is typically the filter associated with coadds.
+    keys:
+      -
+        name: name
+        type: string
+        length: 32
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.query.QueryDimensionRecordStorage
+        view_of: physical_filter
+
+  physical_filter:
+    doc: >
+      A filter associated with a particular instrument.  physical_filters are
+      used to identify datasets that can only be associated with a single
+      observation.
+    keys:
+      -
+        name: name
+        type: string
+        length: 32
+    requires:
+      - instrument
+    implies:
+      - band
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  subfilter:
+    doc: >
+      A mathematical division of an band. Subfilters are used to
+      model wavelength-dependent effects such as differential chromatic
+      refraction.
+    keys:
+      -
+        name: id
+        type: int
+    requires:
+      - band
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  detector:
+    doc: >
+      A detector associated with a particular instrument (not an observation
+      of that detector; that requires specifying an exposure or visit as
+      well).
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      -
+        name: name_in_raft
+        type: string
+        length: 32
+      -
+        name: raft
+        type: string
+        length: 32
+        doc: >
+          A string name for a group of detectors with an instrument-dependent
+          interpretation.
+      -
+        name: purpose
+        type: string
+        length: 32
+        doc: >
+          Role of the detector; typically one of "SCIENCE", "WAVEFRONT",
+          or "GUIDE", though instruments may define additional values.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit:
+    doc: >
+      A sequence of observations processed together, comprised of one or
+      more exposures from the same instrument with the same pointing and
+      physical_filter.
+      The visit table contains metadata that is both meaningful only for
+      science exposures and the same for all exposures in a visit.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    implies: [physical_filter, visit_system]
+    metadata:
+      -
+        name: day_obs
+        type: int
+        doc: >
+          Day of observation as defined by the observatory (YYYYMMDD format).
+          If a visit crosses multiple days this entry will be the earliest
+          day of any of the exposures that make up the visit.
+      -
+        name: exposure_time
+        type: float
+        doc: >
+          The total exposure time of the visit in seconds.  This should
+          be equal to the sum of the exposure_time values for all
+          constituent exposures (i.e. it should not include time between
+          exposures).
+      -
+        name: target_name
+        type: string
+        length: 64
+        doc: Object of interest for this visit or survey field name.
+      -
+        name: observation_reason
+        type: string
+        length: 32
+        doc: >
+          The reason this visit was taken. (e.g. science,
+          filter scan, unknown, various).
+      -
+        name: science_program
+        type: string
+        length: 64
+        doc: Observing program (survey or proposal) identifier.
+      -
+        name: zenith_angle
+        type: float
+        doc: >
+          Approximate zenith angle in degrees during the visit.
+          Can only be approximate since it is continuously changing during
+          and observation and multiple visits can be combined from a
+          relatively long period.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  exposure:
+    doc: >
+      An observation associated with a particular instrument.  All direct
+      observations are identified with an exposure, but derived datasets
+      that may be based on more than one exposure (e.g. multiple snaps) are
+      typically identified with visits instead, even for instruments that
+      don't have multiple exposures per visit.  As a result, instruments
+      that don't have multiple exposures per visit will typically have visit
+      entries that are essentially duplicates of their exposure entries.
+
+      The exposure table contains metadata entries that are relevant for
+      calibration exposures, and does not duplicate entries in visit that
+      would be the same for all exposures within a visit with the exception
+      of the exposure.group entry.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: obs_id
+        type: string
+        length: 64
+    requires: [instrument]
+    implies: [physical_filter]
+    metadata:
+      -
+        name: exposure_time
+        type: float
+        doc: Duration of the exposure with shutter open (seconds).
+      -
+        name: dark_time
+        type: float
+        doc: Duration of the exposure with shutter closed (seconds).
+      -
+        name: observation_type
+        type: string
+        length: 16
+        doc: The observation type of this exposure (e.g. dark, bias, science).
+      -
+        name: observation_reason
+        type: string
+        length: 32
+        doc: >
+          The reason this observation was taken. (e.g. science,
+          filter scan, unknown).
+      -
+        name: day_obs
+        type: int
+        doc: >
+          Day of observation as defined by the observatory (YYYYMMDD format).
+      -
+        name: seq_num
+        type: int
+        doc: >
+          Counter for the observation within a larger sequence. Context
+          of the sequence number is observatory specific. Can be
+          a global counter or counter within day_obs.
+      -
+        name: group_name
+        type: string
+        length: 64
+        doc: >
+          String group identifier associated with this exposure by the
+          acquisition system.
+      -
+        name: group_id
+        type: int
+        doc: >
+          Integer group identifier associated with this exposure by the
+          acquisition system.
+      -
+        name: target_name
+        type: string
+        length: 64
+        doc: Object of interest for this observation or survey field name.
+      -
+        name: science_program
+        type: string
+        length: 64
+        doc: >
+          Observing program (survey, proposal, engineering project)
+          identifier.
+      -
+        name: tracking_ra
+        type: float
+        doc: >
+          Tracking ICRS Right Ascension of boresight in degrees. Can be NULL
+          for observations that are not on sky.
+      -
+        name: tracking_dec
+        type: float
+        doc: >
+          Tracking ICRS Declination of boresight in degrees. Can be NULL for
+          observations that are not on sky.
+      -
+        name: sky_angle
+        type: float
+        doc: >
+          Angle of the instrument focal plane on the sky in degrees. Can
+          be NULL for observations that are not on sky, or for observations
+          where the sky angle changes during the observation.
+      -
+        name: zenith_angle
+        type: float
+        doc: >
+          Angle in degrees from the zenith at the start of the exposure.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  skymap:
+    doc: >
+      A set of tracts and patches that subdivide the sky into rectangular
+      regions with simple projections and intentional overlaps.
+    keys:
+      -
+        name: name
+        type: string
+        length: 64
+      -
+        name: hash
+        type: hash
+        nbytes: 40
+        doc: >
+          A hash of the skymap's parameters.
+    metadata:
+      - name: tract_max
+        type: int
+        doc: >
+          Maximum ID for tracts in this skymap, exclusive.
+      - name: patch_nx_max
+        type: int
+        doc: >
+          Number of patches in the x direction in each tract.
+      - name: patch_ny_max
+        type: int
+        doc: >
+          Number of patches in the y direction in each tract.
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  tract:
+    doc: >
+      A large rectangular region mapped to the sky with a single map
+      projection, associated with a particular skymap.
+    keys:
+      -
+        name: id
+        type: int
+    requires: [skymap]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  patch:
+    doc: >
+      A rectangular region within a tract.
+    keys:
+      -
+        name: id
+        type: int
+    requires: [skymap, tract]
+    metadata:
+      -
+        name: cell_x
+        type: int
+        nullable: false
+        doc: >
+          Which column this patch occupies in the tract's grid of patches.
+      -
+        name: cell_y
+        type: int
+        nullable: false
+        doc: >
+          Which row this patch occupies in the tract's grid of patches.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_detector_region:
+    doc: >
+      A many-to-many join table that provides region information for
+      visit-detector combinations.
+    requires: [visit, detector]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_system:
+    doc: >
+      A system of self-consistent visit definitions, within which each
+      exposure should appear at most once.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: name
+        type: string
+        length: 32
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_definition:
+    doc: >
+      A many-to-many join table that relates exposures to the visits they
+      belong to.
+    requires: [exposure, visit_system]
+    implies: [visit]
+    always_join: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+topology:
+  spatial:
+    observation_regions: [visit_detector_region, visit]
+    skymap_regions: [patch, tract]
+
+  temporal:
+    observation_timespans: [exposure, visit]
+
+packers:
+  visit_detector:
+    fixed: [instrument]
+    dimensions: [instrument, visit, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+  exposure_detector:
+    fixed: [instrument]
+    dimensions: [instrument, exposure, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+  tract_patch:
+    fixed: [skymap]
+    dimensions: [skymap, tract, patch]
+    cls: lsst.skymap.packers.SkyMapDimensionPacker
+  tract_patch_band:
+    fixed: [skymap]
+    dimensions: [skymap, tract, patch, band]
+    cls: lsst.skymap.packers.SkyMapDimensionPacker

--- a/tests/data/records.yaml
+++ b/tests/data/records.yaml
@@ -1,0 +1,101 @@
+description: Butler Data Repository Export
+version: 0
+data:
+  -
+    type: dimension
+    element: instrument
+    records:
+      -
+        name: Cam
+        visit_max: 1024
+        exposure_max: 512
+        detector_max: 4
+        class_name: lsst.obs.base.Instrument
+  -
+    type: dimension
+    element: physical_filter
+    records:
+      -
+        instrument: Cam
+        name: g
+        band: g
+      -
+        instrument: Cam
+        name: r
+        band: r
+  -
+    type: dimension
+    element: visit_system
+    records:
+      -
+        instrument: Cam
+        id: 0
+        name: visit-system-0
+  -
+    type: dimension
+    element: exposure
+    records:
+      -
+        instrument: Cam
+        id: 1000
+        physical_filter: g
+        seq_num: 100
+        obs_id: "exp:1000"
+      -
+        instrument: Cam
+        id: 1001
+        physical_filter: g
+        seq_num: 101
+        obs_id: "exp:1001"
+      -
+        instrument: Cam
+        id: 2000
+        physical_filter: r
+        seq_num: 200
+        obs_id: "exp:2000"
+      -
+        instrument: Cam
+        id: 2001
+        physical_filter: r
+        seq_num: 201
+        obs_id: "exp:2001"
+  -
+    type: dimension
+    element: visit
+    records:
+      -
+        instrument: Cam
+        id: 1
+        physical_filter: g
+        name: "visit-1"
+        visit_system: 0
+      -
+        instrument: Cam
+        id: 2
+        physical_filter: r
+        name: "visit-2"
+        visit_system: 0
+  -
+    type: dimension
+    element: visit_definition
+    records:
+      -
+        instrument: Cam
+        visit_system: 0
+        exposure: 1000
+        visit: 1
+      -
+        instrument: Cam
+        visit_system: 0
+        exposure: 1001
+        visit: 1
+      -
+        instrument: Cam
+        visit_system: 0
+        exposure: 2000
+        visit: 2
+      -
+        instrument: Cam
+        visit_system: 0
+        exposure: 2001
+        visit: 2

--- a/tests/test_dimensions_json.py
+++ b/tests/test_dimensions_json.py
@@ -1,0 +1,202 @@
+# This file is part of daf_butler_migrate.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from lsst.daf.butler import Butler, Config, Registry
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+from lsst.daf.butler.transfers import YamlRepoImportBackend
+from lsst.daf.butler_migrate import database, migrate, script
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+_NAMESPACE = "daf_butler"
+
+# alembic revisions
+_REVISION_V0 = "f3bcee34f344"
+_REVISION_V1 = "380002bcbb26"
+_REVISION_V2 = "bf6308af80aa"
+
+
+class DimensionsJsonTestCase(unittest.TestCase):
+    """Tests for migrating of dimensions.json stored configuration."""
+
+    def setUp(self):
+        self.root = makeTestTempDir(TESTDIR)
+        self.mig_path = migrate.MigrationTrees.migrations_folder()
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def make_butler_v0(self) -> Config:
+        """Make new Butler instance with dimensions config v0."""
+        dimensions = os.path.join(TESTDIR, "config", "dimensions-v0.yaml")
+        config = Butler.makeRepo(self.root, dimensionConfig=dimensions)
+        # Need to stamp current versions into alembic.
+        script.migrate_stamp(
+            repo=self.root,
+            mig_path=self.mig_path,
+            purge=False,
+            dry_run=False,
+            namespace=_NAMESPACE,
+            manager=None,
+        )
+        self.db = database.Database.from_repo(self.root)
+        return config
+
+    def load_data(self, registry: Registry, filename: str):
+        """Load registry test data from filename in data folder."""
+        with open(os.path.join(TESTDIR, "data", filename), "r") as stream:
+            backend = YamlRepoImportBackend(stream, registry)
+        backend.register()
+        backend.load(datastore=None)
+
+    def test_upgrade_v1(self):
+        """Test for upgrade/downgrade between v0 and v1.
+
+        No actual schema change in this migration, only check that contents of
+        ``dimensions.json`` is updated.
+        """
+        self.make_butler_v0()
+
+        self.assertIsNone(self.db.dimensions_namespace())
+        versions = self.db.manager_versions(_NAMESPACE)
+        self.assertEqual(versions["dimensions-config"], (_NAMESPACE, "0", _REVISION_V0))
+
+        # Upgrade to v1.
+        script.migrate_upgrade(
+            repo=self.root,
+            revision=_REVISION_V1,
+            mig_path=self.mig_path,
+            one_shot_tree="",
+            sql=False,
+            namespace=_NAMESPACE,
+            options=None,
+        )
+        self.assertEqual(self.db.dimensions_namespace(), _NAMESPACE)
+        versions = self.db.manager_versions()
+        self.assertEqual(versions["dimensions-config"], (_NAMESPACE, "1", _REVISION_V1))
+
+        # Downgrade back to v0.
+        script.migrate_downgrade(
+            repo=self.root,
+            revision=_REVISION_V0,
+            mig_path=self.mig_path,
+            one_shot_tree="",
+            sql=False,
+            namespace=_NAMESPACE,
+        )
+        self.assertIsNone(self.db.dimensions_namespace())
+        versions = self.db.manager_versions(_NAMESPACE)
+        self.assertEqual(versions["dimensions-config"], (_NAMESPACE, "0", _REVISION_V0))
+
+    def test_upgrade_v2(self):
+        """Test for upgrade from v0 to v2.
+
+        Loads some dimension records and verifies that data is migrated
+        correctly.
+        """
+        config = self.make_butler_v0()
+
+        self.assertIsNone(self.db.dimensions_namespace())
+        versions = self.db.manager_versions(_NAMESPACE)
+        self.assertEqual(versions["dimensions-config"], (_NAMESPACE, "0", _REVISION_V0))
+
+        butler = Butler(config, writeable=True)
+        self.load_data(butler.registry, "records.yaml")
+
+        # Check records for v0 attributes.
+        records = list(butler.registry.queryDimensionRecords("visit"))
+        for record in records:
+            self.assertEqual(record.visit_system, 0)
+
+        records = list(butler.registry.queryDimensionRecords("visit_definition"))
+        for record in records:
+            self.assertEqual(record.visit_system, 0)
+
+        del butler
+
+        # Upgrade to v1. We could upgrade to v2 in one step but I want to check
+        # different arguments at each step.
+        script.migrate_upgrade(
+            repo=self.root,
+            revision=_REVISION_V1,
+            mig_path=self.mig_path,
+            one_shot_tree="",
+            sql=False,
+            namespace=_NAMESPACE,
+            options=None,
+        )
+        self.assertEqual(self.db.dimensions_namespace(), _NAMESPACE)
+        versions = self.db.manager_versions()
+        self.assertEqual(versions["dimensions-config"], (_NAMESPACE, "1", _REVISION_V1))
+
+        # Upgrade to v2.
+        script.migrate_upgrade(
+            repo=self.root,
+            revision=_REVISION_V2,
+            mig_path=self.mig_path,
+            one_shot_tree="",
+            sql=False,
+            namespace=None,
+            options={"has_simulated": "0"},
+        )
+        self.assertEqual(self.db.dimensions_namespace(), _NAMESPACE)
+        versions = self.db.manager_versions()
+        self.assertEqual(versions["dimensions-config"], (_NAMESPACE, "2", _REVISION_V2))
+
+        butler = Butler(config, writeable=False)
+
+        # Check records for v2 attributes.
+        records = list(butler.registry.queryDimensionRecords("instrument"))
+        for record in records:
+            self.assertEqual(record.visit_system, 0)
+
+        records = list(butler.registry.queryDimensionRecords("visit"))
+        for record in records:
+            self.assertFalse(hasattr(record, "visit_system"))
+            self.assertIsNone(record.azimuth)
+        self.assertEqual({record.id: record.seq_num for record in records}, {1: 100, 2: 200})
+
+        records = list(butler.registry.queryDimensionRecords("exposure"))
+        for record in records:
+            self.assertFalse(record.has_simulated)
+            self.assertIsNone(record.azimuth)
+            self.assertEqual(record.seq_start, record.seq_num)
+            self.assertEqual(record.seq_end, record.seq_num)
+
+        records = list(butler.registry.queryDimensionRecords("visit_definition"))
+        for record in records:
+            self.assertFalse(hasattr(record, "visit_system"))
+
+        records = list(butler.registry.queryDimensionRecords("visit_system_membership"))
+        self.assertCountEqual(
+            [record.toDict() for record in records],
+            [
+                {"instrument": "Cam", "visit_system": 0, "visit": 1},
+                {"instrument": "Cam", "visit_system": 0, "visit": 2},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented few migrations for the schema of dimensions tables:

- Introduced new concept of `dimensions-config` manager, which represents dimensions configuration in the stored `dimensions.json` object. That manager version is tied to a specific `namespace` value in `dimensions.json`, every namespace could have a different migration path, similarly to different manager classes for other managers.
- Added migration branch for `daf_butler` namespace, starting with version 0.
- Added migration script for `daf_butler` namespace from version 0 to version 1, this adds `namespace` key to the configuration, plus adds `healpix` to skypix config.
- Added migration script for `dimensions` manager, from StaticDimensionRecordStorageManager 6.0.1 to 6.0.2. This makes implied dimensions columns not-NULL.
- Added migration script for `daf_butler` namespace from version 1 to version 2. It changes how visit_system and exposure-to-visit mapping is implemented.

In addition to the migration scripts above, few other improvements to the tooling were made:
- New command `butler migrate set-namespace` added to add `namespace` to `dimensions.json` without doing full migration (and without changing `version` number).
- New command `butler migrate dump-schema` added to help dump schema in a format that is better suited for comparing it with other versions of the same schema. Can be used for checking migrated schema against the schema created from scratch using new version of the code.
- Some CLI commands now accept (or require) additional options, e.g. when `namespace` is not present in `dimensions.json`, one has to specify it on command line with `--namespace` option. Some migrations scripts need additional options, these can be passed with `--options` option to `upgrade` command.