### PR TITLE
DM-36766: Add migration scripts for obscore manager and its config.

### DIFF
--- a/migrations/obscore-config/2daeabfb5019.py
+++ b/migrations/obscore-config/2daeabfb5019.py
@@ -1,0 +1,23 @@
+"""This is an initial pseudo-revision of the 'obscore-config' tree.
+
+Revision ID: 2daeabfb5019
+Revises:
+Create Date: 2022-10-28 10:48:54.550498
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2daeabfb5019"
+down_revision = None
+branch_labels = ("obscore-config",)
+depends_on = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError()
+
+
+def downgrade() -> None:
+    raise NotImplementedError()

--- a/migrations/obscore-config/5449f6e37baf.py
+++ b/migrations/obscore-config/5449f6e37baf.py
@@ -1,0 +1,122 @@
+"""Migration script for obscore-config namespace=oga version=1.
+
+Revision ID: 5449f6e37baf
+Revises: 2daeabfb5019
+Create Date: 2022-10-28 10:52:49.700164
+
+"""
+
+import json
+
+import yaml
+from alembic import context, op
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+
+# revision identifiers, used by Alembic.
+revision = "5449f6e37baf"
+down_revision = "2daeabfb5019"
+branch_labels = ("obscore-config-oga",)
+depends_on = None
+
+# Namespace
+_NAMESPACE = "oga"
+
+# Version
+_VERSION = 1
+
+
+def upgrade() -> None:
+    """Upgrade from "no-config" to version 1.
+
+    Summary of changes for this upgrade:
+
+        - obscore manager has to be defined in the butler_attributes table
+        - add "config:obscore.json" key to butler_attributes table
+
+    The script reads obscore configuration from YAML file
+    """
+
+    obscore_config = _read_obscore_config()
+    _migrate(obscore_config)
+
+    # We have to create actual obscore table, and using the manager is the
+    # only reasonable way to do it.
+
+    print(
+        "*** Before anything can be written the upgraded Registry you need to run\n"
+        "*** `butler obscore-make-table` command (defined in dax_obscore package)."
+    )
+
+
+def downgrade() -> None:
+    """Upgrade from version 1 to "no-config".
+
+    Summary of changes for this upgrade:
+
+        - delete "config:obscore.json" key from butler_attributes table
+    """
+
+    _migrate(None)
+
+
+def _migrate(obscore_config: dict | None) -> None:
+    """Upgrade or downgrade schema."""
+
+    mig_context = context.get_context()
+    schema = mig_context.version_table_schema
+    bind = op.get_bind()
+
+    attributes = ButlerAttributes(bind, schema)
+
+    # Check the key in butler_attributes.
+    obscore_json_key = "config:obscore.json"
+    value = attributes.get(obscore_json_key)
+    if obscore_config is not None:
+        if value is not None:
+            raise KeyError(f"Key {obscore_json_key!r} is already defined in butler_attributes.")
+    else:
+        if value is None:
+            raise KeyError(f"Key {obscore_json_key!r} is not defined in butler_attributes.")
+
+    if obscore_config is not None:
+        config_str = json.dumps(obscore_config)
+        attributes.insert(obscore_json_key, config_str)
+    else:
+        attributes.delete(obscore_json_key)
+
+
+def _read_obscore_config() -> dict:
+    """Read obscore configuration from YAML file."""
+
+    config = context.config
+    obscore_config_path = config.get_section_option("daf_butler_migrate_options", "obscore_config")
+    if obscore_config_path is None:
+        raise ValueError(
+            "This migration script requires an obscore configuration file in YAML format."
+            " Please use `--options obscore_config=<path>` command line option."
+        )
+
+    # Ideally we want to verify YAML file to match obscore configuration, but
+    # that means bringing a lot of dependencies here which I do not want to do.
+    # So just parse YAML, check required fields and convert to JSON.
+    with open(obscore_config_path) as yaml_file:
+        obscore_config = yaml.safe_load(yaml_file)
+
+    namespace = obscore_config.get("namespace")
+    version = obscore_config.get("version")
+    if namespace is None:
+        raise ValueError("Namespace is not defined in configuration file")
+    if namespace != _NAMESPACE:
+        raise ValueError(
+            f"Namespace defined in configuration file ({namespace}) "
+            f"does not match expected namespace {_NAMESPACE}"
+        )
+    if version is None:
+        raise ValueError("Version is not defined in configuration file")
+    if version != _VERSION:
+        raise ValueError(
+            f"Version defined in configuration file ({version}) "
+            f"does not match expected version {_VERSION}"
+        )
+
+    return obscore_config

--- a/migrations/obscore/8b8e030aba2b.py
+++ b/migrations/obscore/8b8e030aba2b.py
@@ -1,0 +1,23 @@
+"""This is an initial pseudo-revision of the 'obscore' tree.
+
+Revision ID: 8b8e030aba2b
+Revises:
+Create Date: 2022-10-27 16:03:57.771563
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8b8e030aba2b"
+down_revision = None
+branch_labels = ("obscore",)
+depends_on = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError()
+
+
+def downgrade() -> None:
+    raise NotImplementedError()

--- a/migrations/obscore/a0d766f99876.py
+++ b/migrations/obscore/a0d766f99876.py
@@ -1,0 +1,84 @@
+"""Migration script for ObsCoreLiveTableManager 0.0.1.
+
+Revision ID: a0d766f99876
+Revises: 8b8e030aba2b
+Create Date: 2022-10-27 16:05:17.523936
+
+"""
+
+from alembic import context, op
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+
+# revision identifiers, used by Alembic.
+revision = "a0d766f99876"
+down_revision = "8b8e030aba2b"
+branch_labels = ("obscore-ObsCoreLiveTableManager",)
+depends_on = None
+
+# butler_attributes key for obscore
+OBSCORE_CONFIG_KEY = "config:registry.managers.obscore"
+
+# Manager name
+MANAGER = "lsst.daf.butler.registry.obscore._manager.ObsCoreLiveTableManager"
+
+# Version string
+MANAGER_VERSION = "0.0.1"
+
+
+def upgrade() -> None:
+    """Summary of changes for this migration:
+
+        - add obscore manager entry to butler_attributes table.
+
+    Notes
+    -----
+    This migration has to be used together with ``obscore-config`` migration
+    script which creates actual obscore table.
+    """
+    _migrate(upgrade=True)
+
+    print(
+        "*** Do not forget to add this line to butler.yaml file (registry.managers):\n"
+        f"***     obscore: {MANAGER}"
+    )
+
+
+def downgrade() -> None:
+    """Summary of changes for this migration:
+
+        - remove obscore manager entry from butler_attributes table.
+
+    Notes
+    -----
+    This migration has to be used together with ``obscore-config`` migration
+    script which should remove actual obscore table.
+    """
+    _migrate(upgrade=False)
+
+
+def _migrate(upgrade: bool) -> None:
+    """Upgrade or downgrade schema."""
+
+    mig_context = context.get_context()
+    schema = mig_context.version_table_schema
+    bind = op.get_bind()
+
+    attributes = ButlerAttributes(bind, schema)
+    version_key = f"version:{MANAGER}"
+
+    # Check the keys in butler_attributes.
+    for key in (OBSCORE_CONFIG_KEY, version_key):
+        value = attributes.get(key)
+        if upgrade:
+            if value is not None:
+                raise KeyError(f"Key {key!r} is already defined in butler_attributes.")
+        else:
+            if value is None:
+                raise KeyError(f"Key {key!r} is not defined in butler_attributes.")
+
+    if upgrade:
+        attributes.insert(OBSCORE_CONFIG_KEY, MANAGER)
+        attributes.insert(version_key, MANAGER_VERSION)
+    else:
+        attributes.delete(OBSCORE_CONFIG_KEY)
+        attributes.delete(version_key)

--- a/python/lsst/daf/butler_migrate/butler_attributes.py
+++ b/python/lsst/daf/butler_migrate/butler_attributes.py
@@ -63,6 +63,19 @@ class ButlerAttributes:
         row = result.fetchone()
         return row[0] if row is not None else None
 
+    def insert(self, name: str, value: str) -> None:
+        """Insert new parameter in butler_attributes table.
+
+        Parameters
+        ----------
+        name : `str`
+            New attribute name.
+        value : `str`
+            Attribute value.
+        """
+        sql = self._table.insert().values(name=name, value=value)
+        self._connection.execute(sql)
+
     def update(self, name: str, value: str) -> int:
         """Update the value of existing parameter in butler_attributes table.
 
@@ -82,6 +95,17 @@ class ButlerAttributes:
         # update version
         sql = self._table.update().where(self._table.columns.name == name).values(value=value)
         return self._connection.execute(sql).rowcount
+
+    def delete(self, name: str) -> None:
+        """Delete parameter from butler_attributes table.
+
+        Parameters
+        ----------
+        name : `str`
+            Attribute name.
+        """
+        sql = self._table.delete().where(self._table.columns.name == name)
+        self._connection.execute(sql)
 
     def get_dimensions_json(self) -> Dict[str, Any]:
         """Return dimensions configuration from dimensions.json.

--- a/python/lsst/daf/butler_migrate/cli/opt/arguments.py
+++ b/python/lsst/daf/butler_migrate/cli/opt/arguments.py
@@ -51,7 +51,9 @@ manager_argument = MWArgumentDecorator(
     "manager",
     help=(
         "MANAGER is a name of the manager for which to stamp the revision, "
-        "if missing then all managers are stamped."
+        "if missing then all managers already defined in butler_attributes "
+        "are stamped. To stamp initial revision for a manager not in "
+        "butler_attributes, provide its name explicitly."
     ),
     required=False,
 )

--- a/python/lsst/daf/butler_migrate/config.py
+++ b/python/lsst/daf/butler_migrate/config.py
@@ -42,6 +42,7 @@ class MigAlembicConfig(Config):
         cls,
         mig_path: str,
         *args: Any,
+        repository: Optional[str] = None,
         db: Optional[database.Database] = None,
         single_tree: Optional[str] = None,
         one_shot_tree: Optional[str] = None,
@@ -54,6 +55,8 @@ class MigAlembicConfig(Config):
         ----------
         mig_path : `str`
             Filesystem path to location of revision trees.
+        repository : `str`
+            Path to repository configuration file.
         db : `database.Database`
             Object encapsulating access to database information.
         single_tree : `str`, optional
@@ -99,6 +102,9 @@ class MigAlembicConfig(Config):
         # [daf_butler_migrate] section exists
         cfg.set_section_option("daf_butler_migrate", "_daf_butler_migrate", "")
         cfg.set_section_option("daf_butler_migrate_options", "_daf_butler_migrate_options", "")
+
+        if repository is not None:
+            cfg.set_section_option("daf_butler_migrate", "repository", repository)
 
         if db is not None:
             # URL may contain URL-encoded items which include % sign, and that

--- a/python/lsst/daf/butler_migrate/config.py
+++ b/python/lsst/daf/butler_migrate/config.py
@@ -101,7 +101,11 @@ class MigAlembicConfig(Config):
         cfg.set_section_option("daf_butler_migrate_options", "_daf_butler_migrate_options", "")
 
         if db is not None:
-            cfg.set_main_option("sqlalchemy.url", db.db_url)
+            # URL may contain URL-encoded items which include % sign, and that
+            # needs to be escaped with another % before it is passed to
+            # ConfigParser.
+            url = db.db_url.replace("%", "%%")
+            cfg.set_main_option("sqlalchemy.url", url)
             if db.schema:
                 cfg.set_section_option("daf_butler_migrate", "schema", db.schema)
 

--- a/python/lsst/daf/butler_migrate/migrate.py
+++ b/python/lsst/daf/butler_migrate/migrate.py
@@ -21,17 +21,8 @@
 
 from __future__ import annotations
 
-import logging
 import os
-import uuid
 from typing import Dict, List, Optional
-
-_LOG = logging.getLogger(__name__)
-
-NS_UUID = uuid.UUID("840b31d9-05cd-5161-b2c8-00d32b280d0f")
-"""Namespace UUID used for UUID5 generation. Do not change. This was
-produced by `uuid.uuid5(uuid.NAMESPACE_DNS, "lsst.org")`.
-"""
 
 
 class MigrationTrees:

--- a/python/lsst/daf/butler_migrate/registry.py
+++ b/python/lsst/daf/butler_migrate/registry.py
@@ -1,0 +1,37 @@
+# This file is part of daf_butler_migrate.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from lsst.daf.butler import Registry
+
+
+def make_registry(repository: str, writeable: bool = True) -> Registry:
+    """Make Registry instance.
+
+    Parameters
+    ----------
+    repository : `str`
+        Path to Butler repository configuration file.
+    writeable : `bool`, optional
+        If `True` (default) create a read-write connection to the database.
+    """
+    return Registry.fromConfig(config=repository, writeable=writeable)

--- a/python/lsst/daf/butler_migrate/script/migrate_current.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_current.py
@@ -29,7 +29,7 @@ from typing import Optional
 
 from alembic import command
 
-from .. import config, database
+from .. import config, database, scripts
 
 _LOG = logging.getLogger(__name__)
 
@@ -61,6 +61,7 @@ def migrate_current(repo: str, mig_path: str, verbose: bool, butler: bool, names
             " stored dimensions configuration"
         )
 
+    cfg: config.MigAlembicConfig | None = None
     if butler:
         # Print current versions defined in butler.
         manager_versions = db.manager_versions(namespace)
@@ -77,4 +78,7 @@ def migrate_current(repo: str, mig_path: str, verbose: bool, butler: bool, names
     # complain if alembic_version table is there but does not match manager
     # versions
     if db.alembic_revisions():
-        db.validate_revisions(namespace)
+        if cfg is None:
+            cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db)
+        script_info = scripts.Scripts(cfg)
+        db.validate_revisions(namespace, script_info.base_revisions())

--- a/python/lsst/daf/butler_migrate/script/migrate_current.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_current.py
@@ -72,13 +72,13 @@ def migrate_current(repo: str, mig_path: str, verbose: bool, butler: bool, names
             print("No manager versions defined in butler_attributes table.")
     else:
         # Revisions from alembic
-        cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db)
+        cfg = config.MigAlembicConfig.from_mig_path(mig_path, repository=repo, db=db)
         command.current(cfg, verbose=verbose)
 
     # complain if alembic_version table is there but does not match manager
     # versions
     if db.alembic_revisions():
         if cfg is None:
-            cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db)
+            cfg = config.MigAlembicConfig.from_mig_path(mig_path, repository=repo, db=db)
         script_info = scripts.Scripts(cfg)
         db.validate_revisions(namespace, script_info.base_revisions())

--- a/python/lsst/daf/butler_migrate/script/migrate_downgrade.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_downgrade.py
@@ -74,7 +74,7 @@ def migrate_downgrade(
     one_shot_arg: Optional[str] = None
     if one_shot_tree:
         one_shot_arg = one_shot_tree
-    cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db, one_shot_tree=one_shot_arg)
+    cfg = config.MigAlembicConfig.from_mig_path(mig_path, repository=repo, db=db, one_shot_tree=one_shot_arg)
 
     # check that alembic versions are consistent with butler
     script_info = scripts.Scripts(cfg)

--- a/python/lsst/daf/butler_migrate/script/migrate_stamp.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_stamp.py
@@ -79,7 +79,7 @@ def migrate_stamp(
             # If specified manager not in the database, it may mean that an
             # initial "tree-root" revision needs to be added to alembic
             # table, if that manager is defined in the migration trees.
-            cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db)
+            cfg = config.MigAlembicConfig.from_mig_path(mig_path, repository=repo, db=db)
             script_info = scripts.Scripts(cfg)
             base_revision = revision.rev_id(manager)
             if base_revision not in script_info.base_revisions():
@@ -92,6 +92,6 @@ def migrate_stamp(
             print(f"  {manager}: {rev_id}")
     else:
         if cfg is None:
-            cfg = config.MigAlembicConfig.from_mig_path(mig_path, db=db)
+            cfg = config.MigAlembicConfig.from_mig_path(mig_path, repository=repo, db=db)
         for rev in revisions.values():
             command.stamp(cfg, rev, purge=purge)

--- a/python/lsst/daf/butler_migrate/script/migrate_upgrade.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_upgrade.py
@@ -81,7 +81,7 @@ def migrate_upgrade(
     if one_shot_tree:
         one_shot_arg = one_shot_tree
     cfg = config.MigAlembicConfig.from_mig_path(
-        mig_path, db=db, one_shot_tree=one_shot_arg, migration_options=options
+        mig_path, repository=repo, db=db, one_shot_tree=one_shot_arg, migration_options=options
     )
 
     # check that alembic versions are consistent with butler

--- a/python/lsst/daf/butler_migrate/script/migrate_upgrade.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_upgrade.py
@@ -29,7 +29,7 @@ from typing import Dict, Optional
 
 from alembic import command
 
-from .. import config, database
+from .. import config, database, scripts
 
 _LOG = logging.getLogger(__name__)
 
@@ -77,14 +77,15 @@ def migrate_upgrade(
             "Alembic version table does not exist, you may need to run `butler migrate stamp` first."
         )
 
-    # check that alembic versions are consistent with butler
-    db.validate_revisions(namespace)
-
     one_shot_arg: Optional[str] = None
     if one_shot_tree:
         one_shot_arg = one_shot_tree
     cfg = config.MigAlembicConfig.from_mig_path(
         mig_path, db=db, one_shot_tree=one_shot_arg, migration_options=options
     )
+
+    # check that alembic versions are consistent with butler
+    script_info = scripts.Scripts(cfg)
+    db.validate_revisions(namespace, script_info.base_revisions())
 
     command.upgrade(cfg, revision, sql=sql)

--- a/python/lsst/daf/butler_migrate/scripts.py
+++ b/python/lsst/daf/butler_migrate/scripts.py
@@ -1,0 +1,50 @@
+# This file is part of daf_butler_migrate.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+class Scripts:
+    """Class that provides convenience methods for obtaining information about
+    migration scripts.
+
+    Parameters
+    ----------
+    config : `alembic.config.Config`
+        Alembic configuration.
+    """
+
+    def __init__(self, config: Config):
+        self.scripts = ScriptDirectory.from_config(config)
+
+    def base_revisions(self) -> list[str]:
+        """Return list of all base revisions, or roots of the migration trees.
+
+        Returns
+        -------
+        bases : `list` [`str`]
+            Base revisions, corresponding to the roots of the each manager
+            migration tree.
+        """
+        return list(self.scripts.get_bases())


### PR DESCRIPTION
This adds scripts for `obscore` manager and its corresponding `obscore-config` pseudo-manager (similar to dimensions manager). Obscore schema is more complicated and dynamic (it depends on configuration) compared to all other tables, so we have to rely on actual daf_butler classes to generate table definition. This brings more dependencies that were here before with potential future complications. The migration does not fill obscore table from data already in registry, there is a separate CLI command for that in `dax_obscore` package which has to be run after migration.