### PR TITLE
DM-38349: Update for sqlalchemy 2 and fix mypy issues

### DIFF
--- a/migrations/dimensions-config/380002bcbb26.py
+++ b/migrations/dimensions-config/380002bcbb26.py
@@ -59,12 +59,12 @@ def downgrade() -> None:
 
 
 def _migrate(update_config: Callable[[Dict], Dict]) -> None:
-
     mig_context = context.get_context()
 
     # When we use schemas in postgres then all tables belong to the same schema
     # so we can use alembic's version_table_schema to see where everything goes
     schema = mig_context.version_table_schema
 
+    assert mig_context.bind is not None
     attributes = ButlerAttributes(mig_context.bind, schema)
     attributes.update_dimensions_json(update_config)

--- a/migrations/dimensions-config/c5ae3a2cd7c2.py
+++ b/migrations/dimensions-config/c5ae3a2cd7c2.py
@@ -35,7 +35,6 @@ def downgrade() -> None:
 
 
 def _migrate(old_version: int, new_version: int, column_size: int) -> None:
-
     mig_context = context.get_context()
 
     # When we use schemas in postgres then all tables belong to the same schema
@@ -59,13 +58,13 @@ def _migrate(old_version: int, new_version: int, column_size: int) -> None:
         return config
 
     # Update attributes
+    assert mig_context.bind is not None
     attributes = ButlerAttributes(mig_context.bind, schema)
     attributes.update_dimensions_json(_update_config)
 
     # Update actual schema
     for table_name in ("visit", "exposure"):
         with op.batch_alter_table(table_name, schema=schema) as batch_op:
-
             # change column type
             column = "observation_reason"
             column_type = sa.String(column_size)

--- a/migrations/obscore-config/4fe28ef5030f.py
+++ b/migrations/obscore-config/4fe28ef5030f.py
@@ -165,5 +165,6 @@ def _make_obscore_table(obscore_config: dict) -> None:
     # Note that we are using bind from migration context, and not from
     # Registry. This should work in general, but watch for any surprises.
     # Reflecting metadata is needed for foreign key in obscore table.
+    assert database._metadata is not None
     database._metadata.reflect(bind, schema=schema)
     manager.table.create(bind)

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,9 +6,6 @@ ignore_missing_imports = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
-[mypy-alembic.*]
-ignore_missing_imports = True
-
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True
 

--- a/python/lsst/daf/butler_migrate/butler_attributes.py
+++ b/python/lsst/daf/butler_migrate/butler_attributes.py
@@ -40,7 +40,7 @@ class ButlerAttributes:
 
     def __init__(self, connection: sqlalchemy.engine.Connection, schema: Optional[str] = None):
         self._connection = connection
-        metadata = sqlalchemy.schema.MetaData(connection, schema=schema)
+        metadata = sqlalchemy.schema.MetaData(schema=schema)
         self._table = sqlalchemy.schema.Table(
             "butler_attributes", metadata, autoload_with=connection, schema=schema
         )

--- a/python/lsst/daf/butler_migrate/digests.py
+++ b/python/lsst/daf/butler_migrate/digests.py
@@ -25,7 +25,8 @@ __all__ = ["get_digest"]
 
 
 import hashlib
-from typing import Iterable, Set
+from collections.abc import Iterable
+from typing import cast
 
 import sqlalchemy
 
@@ -34,7 +35,7 @@ def get_digest(
     tables: Iterable[sqlalchemy.schema.Table],
     dialect: sqlalchemy.engine.Dialect,
     *,
-    nullable_columns: Set[str] = set(),
+    nullable_columns: set[str] = set(),
 ) -> str:
     """Calculate digest for a schema based on list of tables schemas.
 
@@ -71,7 +72,7 @@ def get_digest(
 
 
 def _tableSchemaRepr(
-    table: sqlalchemy.schema.Table, dialect: sqlalchemy.engine.Dialect, nullable_columns: Set[str]
+    table: sqlalchemy.schema.Table, dialect: sqlalchemy.engine.Dialect, nullable_columns: set[str]
 ) -> str:
     """Make string representation of a single table schema.
 
@@ -102,7 +103,7 @@ def _tableSchemaRepr(
     for fkConstr in table.foreign_key_constraints:
         # for foreign key we include only one side of relations into
         # digest, other side could be managed by different extension
-        fkReps = ["FK", fkConstr.name] + [fk.column.name for fk in fkConstr.elements]
+        fkReps = ["FK", cast(str, fkConstr.name)] + [fk.column.name for fk in fkConstr.elements]
         fkRep = ",".join(fkReps)
         schemaReps += [fkRep]
     # sort everything to keep it stable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click >7.0
-sqlalchemy >= 1.4, < 2
+sqlalchemy
 alembic
 lsst-daf-butler
 lsst-utils

--- a/run_mypy.sh
+++ b/run_mypy.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-export MYPYPATH=$PWD/python
-
 # migration scripts have common names, need to run mypy separately on
 # each migration tree
-for f in python migrations/*; do
+for f in python tests migrations/*; do
     echo Checking $f
     mypy $f
 done

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -65,7 +65,7 @@ def make_revision_tables(
     make_alembic: bool = True,
     fill_alembic: bool = True,
     broken_alembic: bool = False,
-) -> Iterator[str]:
+) -> Iterator[sqlalchemy.engine.url.URL]:
     """Create simple sqlite database with butler_attributes populated.
 
     Yields
@@ -88,9 +88,9 @@ def make_revision_tables(
                 queries += _queries_alembic_version[1:]
 
     with temporaryDirectory() as folder:
-        db_url = f"sqlite:///{folder}/test_db.sqlite3"
+        db_url = sqlalchemy.engine.make_url(f"sqlite:///{folder}/test_db.sqlite3")
         engine = sqlalchemy.create_engine(db_url)
-        with engine.connect() as conn:
+        with engine.begin() as conn:
             for query in queries:
                 conn.execute(sqlalchemy.text(query))
         yield db_url


### PR DESCRIPTION
Lots of mypy/black changes sprinkled with few sqlalchemy 2 updates. I ran mypy with both SA 1.4 and SA 2. Tests were also done in both SA releases, and I unpinned SA version in requirements, GA now runs with SA 2.