### PR TITLE
DM-37322: Add migration script for datasets manager, schema upgrade to 2.0.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] added documentation for a new migration script

--- a/doc/lsst.daf.butler_migrate/common-migrations.rst
+++ b/doc/lsst.daf.butler_migrate/common-migrations.rst
@@ -1,0 +1,87 @@
+
+##########################
+Common migration operatios
+##########################
+
+This page collects recipes for common migration tasks happening in the migration scripts.
+
+The most important thing to remember is that due to the very limited support of ALTER TABLE syntax in SQLite backend, many migration operations have to use Alembic `batch migrations`_.
+
+
+Defining constraints for string columns
+=======================================
+
+In daf_butler code string columns are naturally defined with a corresponding size.
+SQLAlchemy has a very relaxed type system, to help us detect possible violations we also define check constraints on string columns.
+In registry it all is handled transparently, but in migration script we cannot use that logic, so we have to reproduce it locally.
+
+An example to defining check constraint for a string column::
+
+    with op.batch_alter_table(table_name, schema=schema) as batch_op:
+        # ... add or re-define string column
+        batch_op.alter_column(...)
+        if context.get_context().bind.dialect.name == "sqlite":
+            constraint_name = f"{table_name}_len_{column}"
+            constraint = f'length("{column}")<={column_size} AND length("{column}")>=1'
+            batch_op.drop_constraint(constraint_name)  # only if re-defining existing string column
+            batch_op.create_check_constraint(constraint_name, sqlalchemy.text(constraint))
+
+
+Changing column type
+====================
+
+When type of an existing column has to be changed the main complication is how to calculate and fill values for the column after type change.
+
+If the value of the updated column does not need any change (e.g. extending the size of a string column), then it should be trivial (but check above recipe for updating constraint)::
+
+    with op.batch_alter_table(table_name, schema=schema) as batch_op:
+        batch_op.alter_column(column_name, type=...)
+
+If the values for the updated column need to be calculated and it can be done at SQL level then it can be possible to add a new column, fill it with ne values, drop the existing column and rename added one::
+
+    with op.batch_alter_table(table_name, schema=schema) as batch_op:
+        new_name = column_name + "_tmp"
+        batch_op.add_column(new_name, type=..., nullable=True)
+        # ... fill new column
+        batch_op.drop_column(column_name)
+        # "nullable" should be set to a correct value.
+        batch_op.alter_column(new_name, new_column_name=column_name, nullable=...)
+
+More complicated case is when the column is referenced from other tables, its values have to be consistently replaced in all tables.
+This can be done by creating a temporary table which maps old values to new ones and then creating new column in every table and filling it from that temporary table.
+
+PostgreSQL has a special syntax for updating column values when altering column type, in some cases it may be more efficient to use this syntax than creating temporary table.
+An example of this special syntax::
+
+    op.alter_column(
+        "dataset",
+        "ingest_date",
+        schema=schema,
+        type_=column_type,
+        server_default=server_default,
+        postgresql_using="TO_TIMESTAMP(ingest_date / 1000000000.)",
+    )
+
+
+Updating butler_attributes
+==========================
+
+Each migration script is responsible for updating the version of its corresponding manager (if there is a corresponding manager) in the ``butler_attributes`` table.
+Easiest way to do that is by using ``ButlerAttributes`` class, here is a standard way to do it::
+
+    from alembic import op, context
+    from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+
+    MANAGER = "lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager"
+
+    def upgrade():
+        # Do actual schema upgrade then update butler_attributes
+        mig_context = context.get_context()
+        schema = mig_context.version_table_schema
+        attributes = ButlerAttributes(op.get_bind(), schema)
+        attributes.update_manager_version(MANAGER, "6.0.1")
+
+The ``update_manager_version`` method will raise an exception if manager is not defined in ``butler_attributes`` table.
+
+
+.. _batch migrations: https://alembic.sqlalchemy.org/en/latest/batch.html

--- a/doc/lsst.daf.butler_migrate/index.rst
+++ b/doc/lsst.daf.butler_migrate/index.rst
@@ -21,6 +21,7 @@ Database migrations are defined as scripts executed by these tools, this package
    command-line.rst
    migration-scripts.rst
    typical-tasks.rst
+   common-migrations.rst
 
 Migrations catalog
 ==================

--- a/doc/lsst.daf.butler_migrate/migrations/datasets.rst
+++ b/doc/lsst.daf.butler_migrate/migrations/datasets.rst
@@ -4,10 +4,14 @@ Migrations for datasets manager
 
 The ``datasets`` tree has two branches:
 
-- ``datasets-ByDimensionsDatasetRecordStorageManager`` which is the older implementation of the manager using integer dataset IDs.
+- ``datasets-ByDimensionsDatasetRecordStorageManager`` which is the older implementation of the manager using integer dataset IDs, this managet class was removed from the code starting with ``w_2023_10``.
 - ``datasets-ByDimensionsDatasetRecordStorageManagerUUID`` which is the new implementation using UUIDs.
 
-The regular revision tree has migrations defined for all manager versions that have existed in our code, but none of these migrations were actually implemented.
+The regular revision tree has migrations defined for all manager versions that have existed in our code, but only few of these migrations were actually implemented.
+
+
+One-shot migration to UUID
+==========================
 
 There is a one-shot migration implemented for migration from ``ByDimensionsDatasetRecordStorageManager`` 1.0.0 to ``ByDimensionsDatasetRecordStorageManagerUUID`` 1.0.0::
 
@@ -17,3 +21,11 @@ There is a one-shot migration implemented for migration from ``ByDimensionsDatas
     <base> -> 059cc7b7ef13 (datasets), This is an initial pseudo-revision of the 'datasets/int_1.0.0_to_uuid_1.0.0' tree.
 
 The migration script for this one-shot migration is in `2101fbf51ad3.py <https://github.com/lsst-dm/daf_butler_migrate/blob/main/migrations/_oneshot/datasets/int_1.0.0_to_uuid_1.0.0/2101fbf51ad3.py>`_.
+
+
+ByDimensionsDatasetRecordStorageManagerUUID 1.0.0 to 2.0.0
+==========================================================
+
+Migration script: `4e2d7a28475b.py <https://github.com/lsst-dm/daf_butler_migrate/blob/main/migrations/datasets/4e2d7a28475b.py>`_
+
+Changes the type of ``ingest_date`` column in ``dataset`` table from ``TIMESTAMP`` to ``BIGINT``, containing nanoseconds since epoch like many other timestamp columns.

--- a/doc/lsst.daf.butler_migrate/migrations/datasets.rst
+++ b/doc/lsst.daf.butler_migrate/migrations/datasets.rst
@@ -4,7 +4,7 @@ Migrations for datasets manager
 
 The ``datasets`` tree has two branches:
 
-- ``datasets-ByDimensionsDatasetRecordStorageManager`` which is the older implementation of the manager using integer dataset IDs, this managet class was removed from the code starting with ``w_2023_10``.
+- ``datasets-ByDimensionsDatasetRecordStorageManager`` which is the older implementation of the manager using integer dataset IDs, this manager class was removed from the code starting with ``w_2023_10``.
 - ``datasets-ByDimensionsDatasetRecordStorageManagerUUID`` which is the new implementation using UUIDs.
 
 The regular revision tree has migrations defined for all manager versions that have existed in our code, but only few of these migrations were actually implemented.
@@ -28,4 +28,10 @@ ByDimensionsDatasetRecordStorageManagerUUID 1.0.0 to 2.0.0
 
 Migration script: `4e2d7a28475b.py <https://github.com/lsst-dm/daf_butler_migrate/blob/main/migrations/datasets/4e2d7a28475b.py>`_
 
-Changes the type of ``ingest_date`` column in ``dataset`` table from ``TIMESTAMP`` to ``BIGINT``, containing nanoseconds since epoch like many other timestamp columns.
+Changes the type of ``ingest_date`` column in ``dataset`` table from ``TIMESTAMP`` to ``BIGINT``, containing TAI nanoseconds since epoch like many other timestamp columns.
+
+.. attention::
+    This migration script uses an optimized technique for PostgreSQL to convert timestamps with a reasonable performance at large scale.
+    The optimization uses a simplified in-exact approach for calculating TAI timestamp from UTC timestamp stored in database.
+    This approach assumes that all ingest dates are reasonably recent and uses a fixed offset of 37 seconds between TAI and UTC.
+    Non-PostgreSQL backends utilize more exact approach which is significantly slower.

--- a/migrations/attributes/c0e4f9ab4a5d.py
+++ b/migrations/attributes/c0e4f9ab4a5d.py
@@ -56,8 +56,7 @@ def upgrade() -> None:
     count = sum(1 for key, _ in attributes.items() if key.startswith("schema_digest:"))
     _LOG.info("number of schema digests in table after migration: %s", count)
 
-    count = attributes.update(f"version:{MANAGER}", "1.0.1")
-    assert count == 1, "expected to update single row"
+    attributes.update_manager_version(MANAGER, "1.0.1")
 
 
 def downgrade() -> None:

--- a/migrations/datasets/4e2d7a28475b.py
+++ b/migrations/datasets/4e2d7a28475b.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import sqlalchemy as sa
 from alembic import context, op
+from astropy.time import Time
+from lsst.daf.butler.core.time_utils import TimeConverter
 from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
 
 # revision identifiers, used by Alembic.
@@ -33,15 +35,14 @@ _EPOCH = datetime.datetime(1970, 1, 1)
 
 
 def _convert_to_ns(dt: datetime.datetime) -> int:
-    """Convert datetime to nanoseconds."""
-    microseconds = (dt - _EPOCH) // datetime.timedelta(microseconds=1)
-    return microseconds * 1000
+    """Convert datetime to TAI nanoseconds."""
+    return TimeConverter().astropy_to_nsec(Time(dt, scale="utc").tai)
 
 
 def _convert_to_datetime(nsec: int) -> datetime.datetime:
-    """Convert nanoseconds to datetime."""
-    microseconds = nsec // 1000
-    return datetime.datetime.utcfromtimestamp(microseconds / 1e6)
+    """Convert TAI nanoseconds to datetime."""
+    timestamp = TimeConverter().nsec_to_astropy(nsec)
+    return timestamp.utc.to_datetime()
 
 
 def upgrade() -> None:
@@ -54,28 +55,42 @@ def upgrade() -> None:
     """
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
-        # Keep it at microsecond resolution
-        _migrate_pg(
-            sa.BIGINT, None, "CAST(EXTRACT(EPOCH FROM ingest_date) * 1000000 AS BIGINT) * 1000", "2.0.0"
+        print(
+            "*** Note that this migration script converts ingest_date TIMESTAMP, which is\n"
+            "*** in UTC, to nanoseconds in TAI scale. It uses constant offset of 37 seconds\n"
+            "*** between UTC and TAI. This should produce exact values for reasonably\n"
+            "*** recent ingest_date values, but may not be exact for other cases.\n"
         )
+        # Tell postgres to convert timestamp to nanoseconds, but keep it at
+        # microsecond resolution, and add 37 seconds for TAI-UTC difference.
+        using = "CAST((EXTRACT(EPOCH FROM ingest_date) + 37) * 1000000 AS BIGINT) * 1000"
+        _migrate_pg(sa.BIGINT, None, using, "2.0.0")
     else:
-        _migrate_default(sa.BIGINT, _convert_to_ns, "2.0.0")
+        _migrate_default(sa.BIGINT, None, _convert_to_ns, "2.0.0")
 
 
 def downgrade() -> None:
     """Downgrade from version 2.0.0 to version 1.0.0."""
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
-        # Convert from nanoseconds to timestamp. TO_TIMESTAMP returns timestamp
-        # with timezone, and `_migrate_pg` does SET TIME ZONE 0 to keep things
-        # consistent.
-        _migrate_pg(sa.TIMESTAMP, sa.sql.func.now(), "TO_TIMESTAMP(ingest_date / 1000000000.)", "1.0.0")
+        print(
+            "*** Note that this migration script converts ingest_date from nanoseconds in\n"
+            "*** TAI scale to UTC TIMESTAMP. It uses constant offset of 37 seconds between\n"
+            "*** UTC and TAI. This should produce exact values for reasonably recent\n"
+            "*** ingest_date values, but may not be exact for other cases.\n"
+        )
+        # Convert from nanoseconds to timestamp and subtract 37 seconds of
+        # TAI-UTC difference. TO_TIMESTAMP returns timestamp with timezone, and
+        # `_migrate_pg` does SET TIME ZONE 0 to keep things consistent.
+        using = "TO_TIMESTAMP(ingest_date / 1000000000. - 37)"
+        _migrate_pg(sa.TIMESTAMP, sa.sql.func.now(), using, "1.0.0")
     else:
-        _migrate_default(sa.TIMESTAMP, _convert_to_datetime, "1.0.0")
+        _migrate_default(sa.TIMESTAMP, sa.sql.func.now(), _convert_to_datetime, "1.0.0")
 
 
 def _migrate_default(
     column_type: type,
+    server_default: Any,
     convert_method: Callable[[datetime.datetime], int] | Callable[[int], datetime.datetime],
     version: str,
 ) -> None:
@@ -131,9 +146,13 @@ def _migrate_default(
         _LOG.info("Inserted %s rows into temporary table", count)
 
     with op.batch_alter_table("dataset", schema) as batch_op:
+        if server_default is None:
+            # If removing a default it has to be done first
+            batch_op.alter_column("ingest_date", server_default=None)  # type: ignore[attr-defined]
+    with op.batch_alter_table("dataset", schema) as batch_op:
         # Change the type of the column.
         batch_op.alter_column(  # type: ignore[attr-defined]
-            "ingest_date", type_=column_type, server_default=None
+            "ingest_date", type_=column_type, server_default=server_default
         )
 
     # Update ingest date from a temporary table.

--- a/migrations/datasets/4e2d7a28475b.py
+++ b/migrations/datasets/4e2d7a28475b.py
@@ -54,7 +54,7 @@ def upgrade() -> None:
     """
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
-        # Keep it at miscrosecond resolution
+        # Keep it at microsecond resolution
         _migrate_pg(
             sa.BIGINT, None, "CAST(EXTRACT(EPOCH FROM ingest_date) * 1000000 AS BIGINT) * 1000", "2.0.0"
         )

--- a/migrations/datasets/4e2d7a28475b.py
+++ b/migrations/datasets/4e2d7a28475b.py
@@ -1,0 +1,193 @@
+"""Migration script for ByDimensionsDatasetRecordStorageManagerUUID 2.0.0.
+
+Revision ID: 4e2d7a28475b
+Revises: 2101fbf51ad3
+Create Date: 2023-03-31 22:25:32.651155
+
+"""
+
+import datetime
+import itertools
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import context, op
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+
+# revision identifiers, used by Alembic.
+revision = "4e2d7a28475b"
+down_revision = "2101fbf51ad3"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(f"lsst.daf.butler_migrate.{__name__}")
+
+# Manager name
+MANAGER = (
+    "lsst.daf.butler.registry.datasets.byDimensions._manager.ByDimensionsDatasetRecordStorageManagerUUID"
+)
+
+_EPOCH = datetime.datetime(1970, 1, 1)
+
+
+def _convert_to_ns(dt: datetime.datetime) -> int:
+    """Convert datetime to nanoseconds."""
+    microseconds = (dt - _EPOCH) // datetime.timedelta(microseconds=1)
+    return microseconds * 1000
+
+
+def _convert_to_datetime(nsec: int) -> datetime.datetime:
+    """Convert nanoseconds to datetime."""
+    microseconds = nsec // 1000
+    return datetime.datetime.utcfromtimestamp(microseconds / 1e6)
+
+
+def upgrade() -> None:
+    """Upgrade from version 1.0.0 to version 2.0.0.
+
+    Summary of changes:
+
+        - ingest_date column type changed from database-native TIMESTAMP
+          to nanoseconds-since-epoch in TAI scale.
+    """
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # Keep it at miscrosecond resolution
+        _migrate_pg(
+            sa.BIGINT, None, "CAST(EXTRACT(EPOCH FROM ingest_date) * 1000000 AS BIGINT) * 1000", "2.0.0"
+        )
+    else:
+        _migrate_default(sa.BIGINT, _convert_to_ns, "2.0.0")
+
+
+def downgrade() -> None:
+    """Downgrade from version 2.0.0 to version 1.0.0."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # Convert from nanoseconds to timestamp. TO_TIMESTAMP returns timestamp
+        # with timezone, and `_migrate_pg` does SET TIME ZONE 0 to keep things
+        # consistent.
+        _migrate_pg(sa.TIMESTAMP, sa.sql.func.now(), "TO_TIMESTAMP(ingest_date / 1000000000.)", "1.0.0")
+    else:
+        _migrate_default(sa.TIMESTAMP, _convert_to_datetime, "1.0.0")
+
+
+def _migrate_default(
+    column_type: type,
+    convert_method: Callable[[datetime.datetime], int] | Callable[[int], datetime.datetime],
+    version: str,
+) -> None:
+    """Default migration method that does not rely on optimizations.
+
+    This method creates a temporary table which is filled with the converted
+    timestamps, and then updates dataset table from that temporary table. This
+    was only tested with SQLite, may not work with other backends.
+    """
+    mig_context = context.get_context()
+    bind = op.get_bind()
+    assert bind is not None, "Migration only works on actual connection."
+    schema = mig_context.version_table_schema
+    metadata = sa.schema.MetaData(schema=schema)
+
+    table = sa.schema.Table("dataset", metadata, autoload_with=bind, schema=schema)
+
+    # Create a temporary table.
+    tmp_table = sa.schema.Table(
+        "dataset_migration_tmp",
+        metadata,
+        sa.schema.Column("id", table.columns["id"].type, primary_key=True),
+        sa.schema.Column("ingest_date", column_type, nullable=False),
+        prefixes=["TEMPORARY"],
+        schema=sa.schema.BLANK_SCHEMA,
+    )
+    tmp_table.create(bind)
+
+    # There may be very many records in dataset table to fit everything in
+    # memory, so split the whole thing on dataset_type_id.
+    query = sa.select(table.columns["dataset_type_id"]).select_from(table).distinct()
+    result = bind.execute(query).scalars()
+    dataset_type_ids = sorted(result)
+    _LOG.info("Found %s dataset types in dataset table", len(dataset_type_ids))
+
+    for dataset_type_id in dataset_type_ids:
+        # Extract ingest date for datasets.
+        query = (
+            sa.select(table.columns["id"], table.columns["ingest_date"])
+            .select_from(table)
+            .where(table.columns["dataset_type_id"] == dataset_type_id)
+        )
+        result = bind.execute(query)
+        rows = [(dataset_id, convert_method(ingest_date)) for dataset_id, ingest_date in result]
+        _LOG.info("Found %s rows for in dataset type %s", len(rows), dataset_type_id)
+
+        iterator = iter(rows)
+        count = 0
+        while chunk := list(itertools.islice(iterator, 1000)):
+            query = tmp_table.insert().values(chunk)
+            result = bind.execute(query)
+            count += result.rowcount
+        _LOG.info("Inserted %s rows into temporary table", count)
+
+    with op.batch_alter_table("dataset", schema) as batch_op:
+        # Change the type of the column.
+        batch_op.alter_column(  # type: ignore[attr-defined]
+            "ingest_date", type_=column_type, server_default=None
+        )
+
+    # Update ingest date from a temporary table.
+    query = table.update().values(
+        ingest_date=sa.select(tmp_table.columns["ingest_date"])
+        .where(tmp_table.columns["id"] == table.columns["id"])
+        .scalar_subquery()
+    )
+    result = bind.execute(query)
+    _LOG.info("Updated %s rows in dataset table", result.rowcount)
+
+    # Update manager schema version.
+    attributes = ButlerAttributes(bind, schema)
+    attributes.update_manager_version(MANAGER, version)
+
+
+def _migrate_pg(
+    column_type: type,
+    server_default: Any,
+    using: str,
+    version: str,
+) -> None:
+    """Migration method with PostgreSQL-specific optimizations.
+
+    Notes
+    -----
+    Postgres allows in-place type update with re-calculation of the new data
+    values with its special USING syntax which provides an expression for
+    calculating new data values.
+    """
+    mig_context = context.get_context()
+    bind = op.get_bind()
+    assert bind is not None, "Migration only works on actual connection."
+    schema = mig_context.version_table_schema
+
+    # Some conversions may involve conversion of timestamps, make sure
+    # everything is done in UTC.
+    bind.execute(sa.text("SET TIME ZONE 0"))
+
+    _LOG.info("Start updating dataset table")
+    # Change the type of the column.
+    if server_default is None:
+        # If removing a default it has to be done first
+        op.alter_column("dataset", "ingest_date", schema=schema, server_default=None)
+    op.alter_column(
+        "dataset",
+        "ingest_date",
+        schema=schema,
+        type_=column_type,
+        server_default=server_default,
+        postgresql_using=using,
+    )
+    _LOG.info("Finished updating dataset table")
+
+    # Update manager schema version.
+    attributes = ButlerAttributes(bind, schema)
+    attributes.update_manager_version(MANAGER, version)

--- a/migrations/dimensions/035dcf13ef18.py
+++ b/migrations/dimensions/035dcf13ef18.py
@@ -83,8 +83,7 @@ def _do_migration(nullable: bool, manager_version: str) -> None:
                         _LOG.info("Add NOT NULL to column %s.%s", element_name, other_element)
                     batch_op.alter_column(other_element, nullable=nullable)  # type: ignore[attr-defined]
 
-    count = attributes.update(f"version:{MANAGER}", manager_version)
-    assert count == 1, "expected to update single row"
+    attributes.update_manager_version(MANAGER, manager_version)
 
 
 def _check_visit_null_filter() -> None:

--- a/migrations/dimensions/1601d5973bf8.py
+++ b/migrations/dimensions/1601d5973bf8.py
@@ -5,34 +5,31 @@ Revises: 87a30df8c8c5
 Create Date: 2021-09-01 09:43:25.448091
 
 """
-from alembic import op, context
 import sqlalchemy as sa
-
-from lsst.daf.butler_migrate.shrink import shrinkDatabaseEntityName
+from alembic import context, op
 from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
-
+from lsst.daf.butler_migrate.shrink import shrinkDatabaseEntityName
 
 # revision identifiers, used by Alembic.
-revision = '1601d5973bf8'
-down_revision = '87a30df8c8c5'
+revision = "1601d5973bf8"
+down_revision = "87a30df8c8c5"
 branch_labels = None
 depends_on = None
 
 
 # maps table name to columns in new index
 INDICES = {
-    "patch_skypix_overlap": [
-        "skypix_system", "skypix_level", "skypix_index", "skymap", "tract", "patch"
-    ],
-    "tract_skypix_overlap": [
-        "skypix_system", "skypix_level", "skypix_index", "skymap", "tract"
-    ],
+    "patch_skypix_overlap": ["skypix_system", "skypix_level", "skypix_index", "skymap", "tract", "patch"],
+    "tract_skypix_overlap": ["skypix_system", "skypix_level", "skypix_index", "skymap", "tract"],
     "visit_detector_region_skypix_overlap": [
-        "skypix_system", "skypix_level", "skypix_index", "instrument", "detector", "visit"
+        "skypix_system",
+        "skypix_level",
+        "skypix_index",
+        "instrument",
+        "detector",
+        "visit",
     ],
-    "visit_skypix_overlap": [
-        "skypix_system", "skypix_level", "skypix_index", "instrument", "visit"
-    ],
+    "visit_skypix_overlap": ["skypix_system", "skypix_level", "skypix_index", "instrument", "visit"],
 }
 
 # Manager name
@@ -40,8 +37,7 @@ MANAGER = "lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStora
 
 
 def upgrade() -> None:
-    """Upgrade from StaticDimensionRecordStorageManager 6.0.0 to 6.0.1
-    """
+    """Upgrade from StaticDimensionRecordStorageManager 6.0.0 to 6.0.1"""
     # When we use schemas in postgres then all tables belong to the same schema
     # so we can use alembic's version_table_schema to see where everything goes
     mig_context = context.get_context()
@@ -57,13 +53,11 @@ def upgrade() -> None:
         op.create_index(index_name, table_name, columns, schema=schema)
 
     attributes = ButlerAttributes(bind, schema)
-    count = attributes.update(f"version:{MANAGER}", "6.0.1")
-    assert count == 1, "expected to update single row"
+    attributes.update_manager_version(MANAGER, "6.0.1")
 
 
 def downgrade() -> None:
-    """Downgrade from StaticDimensionRecordStorageManager 6.0.1 to 6.0.0
-    """
+    """Downgrade from StaticDimensionRecordStorageManager 6.0.1 to 6.0.0"""
     mig_context = context.get_context()
     schema = mig_context.version_table_schema
     bind = op.get_bind()
@@ -74,5 +68,4 @@ def downgrade() -> None:
         op.drop_index(index_name, table_name, schema=schema)
 
     attributes = ButlerAttributes(bind, schema)
-    count = attributes.update(f"version:{MANAGER}", "6.0.0")
-    assert count == 1, "expected to update single row"
+    attributes.update_manager_version(MANAGER, "6.0.0")

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,9 @@ disallow_incomplete_defs = True
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True
 
+[mypy-astropy.*]
+ignore_missing_imports = True
+
 [mypy-lsst.*]
 ignore_missing_imports = True
 ignore_errors = True

--- a/python/lsst/daf/butler_migrate/butler_attributes.py
+++ b/python/lsst/daf/butler_migrate/butler_attributes.py
@@ -110,6 +110,26 @@ class ButlerAttributes:
         sql = self._table.update().where(self._table.columns.name == name).values(value=value)
         return self._connection.execute(sql).rowcount
 
+    def update_manager_version(self, manager: str, version: str) -> None:
+        """Convenience method for updating version for the specified manager.
+
+        Parameters
+        ----------
+        manager : `str`
+            Manager name.
+        value : `str`
+            New version string.
+
+        Raises
+        ------
+        LookupError
+            Raised if manager is not found in the table.
+        """
+        manager_key = f"version:{manager}"
+        count = self.update(manager_key, version)
+        if count != 1:
+            raise LookupError(f"Manager key {manager_key} is not found in butler_attributes table.")
+
     def delete(self, name: str) -> int:
         """Delete parameter from butler_attributes table.
 

--- a/python/lsst/daf/butler_migrate/script/rewrite_sqlite_registry.py
+++ b/python/lsst/daf/butler_migrate/script/rewrite_sqlite_registry.py
@@ -28,15 +28,7 @@ import tempfile
 from collections import defaultdict
 from typing import Dict
 
-from lsst.daf.butler import (
-    Butler,
-    Config,
-    DatasetAssociation,
-    DatasetId,
-    DatasetIdGenEnum,
-    DatasetRef,
-    SkyPixDimension,
-)
+from lsst.daf.butler import Butler, Config, DatasetAssociation, DatasetId, DatasetRef, SkyPixDimension
 from lsst.daf.butler.datastores.fileDatastore import FileDatastore
 from lsst.daf.butler.registries.sql import SqlRegistry
 from lsst.daf.butler.registry import CollectionType
@@ -191,9 +183,7 @@ def transfer_everything(source_butler: Butler, dest_butler: Butler) -> None:
     # If this is int to UUID we force "raw" to generate reproductible UUID.
     # If other raw-type datasets are to be supported the command will have
     # to take an additional parameter.
-    dest_refs = dest_butler.transfer_from(
-        source_butler, source_refs, skip_missing=False, id_gen_map={"raw": DatasetIdGenEnum.DATAID_TYPE_RUN}
-    )
+    dest_refs = dest_butler.transfer_from(source_butler, source_refs, skip_missing=False)
 
     # Map source ID to destination ID.
     source_to_dest = {source.getCheckedId(): dest for source, dest in zip(source_refs, dest_refs)}


### PR DESCRIPTION
Few additional code and documentation improvements.
New script uses PostgreSQL-specific syntax for updating column values, this accelerates the whole process.
Migration of the whole copy of `main` repo takes less than 4 minutes on my personal machine (with NVMe SSD).