### PR TITLE
DM-37875: Add ltd-upload action

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -46,3 +46,11 @@ jobs:
           DAF_BUTLER_MIGRATE_MIGRATIONS: ./migrations
         working-directory: ./doc
         run: package-docs build -n -W
+
+      - name: Upload to LSST the Docs
+        uses: lsst-sqre/ltd-upload@v1
+        with:
+          project: 'daf-butler-migrate'
+          dir: 'doc/_build/html'
+          username: ${{ secrets.LTD_USERNAME }}
+          password: ${{ secrets.LTD_PASSWORD }}


### PR DESCRIPTION
This action in the build_docs GitHub Action workflow uploads the package documentation to daf-butler-migrate.lsst.io.

