### PR TITLE
DM-40265: Add migration script for dimensions-config (v3 to v4)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
       - name: Update pip/wheel infrastructure
         shell: bash -l {0}
         run: |
-          conda install -y -q "pip<22" wheel
+          conda install -y -q pip wheel
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -21,6 +21,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.3
+    rev: v0.1.7
     hooks:
       - id: ruff

--- a/doc/lsst.daf.butler_migrate/migrations/dimensions-config.rst
+++ b/doc/lsst.daf.butler_migrate/migrations/dimensions-config.rst
@@ -53,3 +53,12 @@ daf_butler 2 to 3
 Migration script: `c5ae3a2cd7c2.py <https://github.com/lsst-dm/daf_butler_migrate/blob/main/migrations/dimensions-config/c5ae3a2cd7c2.py>`_
 
 Changes the size of the ``observation_reason`` column in visit and exposure tables from 32 characters to 68.
+
+
+daf_butler 3 to 4
+=================
+
+Migration script: `9888256c6a18.py <https://github.com/lsst-dm/daf_butler_migrate/blob/main/migrations/dimensions-config/9888256c6a18.py>`_
+
+Does not change the schema, only updates the contents of ``config:dimensions.json``.
+Three elements in dimensions configuration add ``populated_by: visit`` option.

--- a/migrations/_alembic/env.py
+++ b/migrations/_alembic/env.py
@@ -1,5 +1,5 @@
 from alembic import context
-from sqlalchemy import engine, engine_from_config, pool
+from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -50,22 +50,9 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    # executemany_* arguments are postgres-specific, need to check dialect
-    url_str = config.get_main_option("sqlalchemy.url")
-    assert url_str is not None, "Expect URL connection defined."
-    url = engine.url.make_url(url_str)
-    if url.get_dialect().name == "postgresql":
-        kwargs = dict(
-            executemany_mode="values",
-            executemany_values_page_size=10000,
-            executemany_batch_page_size=500,
-        )
-    else:
-        kwargs = {}
-
     config_dict = config.get_section(config.config_ini_section)
     assert config_dict is not None, "Expect non-empty configuration"
-    connectable = engine_from_config(config_dict, prefix="sqlalchemy.", poolclass=pool.NullPool, **kwargs)
+    connectable = engine_from_config(config_dict, prefix="sqlalchemy.", poolclass=pool.NullPool)
 
     schema = config.get_section_option("daf_butler_migrate", "schema")
     with connectable.connect() as connection:

--- a/migrations/_oneshot/datasets/int_1.0.0_to_uuid_1.0.0/2101fbf51ad3.py
+++ b/migrations/_oneshot/datasets/int_1.0.0_to_uuid_1.0.0/2101fbf51ad3.py
@@ -151,7 +151,7 @@ def upgrade() -> None:
 
     # drop mapping table
     _LOG.debug("Dropping mapping table")
-    op.drop_table(ID_MAP_TABLE_NAME, schema)
+    op.drop_table(ID_MAP_TABLE_NAME, schema=schema)
 
     # refresh schema from database
     metadata = sa.schema.MetaData(schema=schema)

--- a/migrations/dimensions-config/9888256c6a18.py
+++ b/migrations/dimensions-config/9888256c6a18.py
@@ -1,0 +1,68 @@
+"""Migration script for dimensions.yaml namespace=daf_butler version=4.
+
+Revision ID: 9888256c6a18
+Revises: c5ae3a2cd7c2
+Create Date: 2023-12-04 18:16:25.375102
+
+"""
+from alembic import context
+from lsst.daf.butler_migrate.butler_attributes import ButlerAttributes
+
+# revision identifiers, used by Alembic.
+revision = "9888256c6a18"
+down_revision = "c5ae3a2cd7c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade from version 3 to version 4 following update of dimension.yaml
+    in DM-34589.
+
+    Summary of changes:
+
+        - Database schema did not change, only contents of
+          `config:dimensions.json` in `butler_attributes`.
+        - Changes in `config:dimensions.json`:
+          - "version" value updated to 4.
+          - "populated_by: visit" added to three elements:
+            `visit_detector_region`, `visit_definition` and
+            `visit_system_membership`.
+    """
+    _migrate(3, 4, True)
+
+
+def downgrade() -> None:
+    """Undo changes made in upgrade()."""
+    _migrate(4, 3, False)
+
+
+def _migrate(old_version: int, new_version: int, upgrade: bool) -> None:
+    """Do migration in either direction."""
+
+    def _update_config(config: dict) -> dict:
+        """Update dimension.json configuration"""
+        assert config["version"] == old_version, f"dimensions.json version mismatch: {config['version']}"
+
+        config["version"] = new_version
+
+        elements = config["elements"]
+        for element_name in ("visit_detector_region", "visit_definition", "visit_system_membership"):
+            element = elements[element_name]
+            if upgrade:
+                element["populated_by"] = "visit"
+            else:
+                del element["populated_by"]
+
+        return config
+
+    mig_context = context.get_context()
+
+    # When we use schemas in postgres then all tables belong to the same schema
+    # so we can use alembic's version_table_schema to see where everything goes
+    schema = mig_context.version_table_schema
+
+    # Update attributes
+    assert mig_context.bind is not None
+    attributes = ButlerAttributes(mig_context.bind, schema)
+    attributes.update_dimensions_json(_update_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 keywords = ["lsst"]
@@ -55,7 +56,7 @@ version = { attr = "lsst_versions.get_lsst_version" }
 
 [tool.black]
 line-length = 110
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
@@ -96,7 +97,7 @@ select = [
     "UP",
     "C4",
 ]
-target-version = "py310"
+target-version = "py311"
 extend-select = [
     "RUF100", # Warn about unused noqa
 ]


### PR DESCRIPTION
Plus few updates to existing code to fix issues from new mypy and sqlalchemy versions.

Tested new migration scrip in my local copy of `main` repo, works fine.

## Checklist

- [X] added documentation for a new migration script
