### PR TITLE
DM-42509: Extend output of show-current command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -15,12 +15,12 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.7
+    rev: v0.1.13
     hooks:
       - id: ruff

--- a/doc/lsst.daf.butler_migrate/typical-tasks.rst
+++ b/doc/lsst.daf.butler_migrate/typical-tasks.rst
@@ -82,13 +82,13 @@ If ``(head)`` is missing then newer revisions exist in the revision history, and
 With the ``--butler`` option this command displays information from the ``butler_attributes`` table::
 
     $ butler migrate show-current --butler $REPO
-    attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager 1.0.0 -> f22a777cf382
-    collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager 2.0.0 -> 8c57494cabcc
-    datasets: lsst.daf.butler.registry.datasets.byDimensions._manager.ByDimensionsDatasetRecordStorageManagerUUID 1.0.0 -> 2101fbf51ad3
-    datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager 0.2.0 -> a07b3b60e369
-    dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager 6.0.2 -> 035dcf13ef18
-    dimensions-config: daf_butler 3 -> c5ae3a2cd7c2
-    opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager 0.2.0 -> 77e5b803ad3f
+    attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager 1.0.0 -> f22a777cf382 (head)
+    collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager 2.0.0 -> 8c57494cabcc (head)
+    datasets: lsst.daf.butler.registry.datasets.byDimensions._manager.ByDimensionsDatasetRecordStorageManagerUUID 1.0.0 -> 2101fbf51ad3 (head)
+    datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager 0.2.0 -> a07b3b60e369 (head)
+    dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager 6.0.2 -> 035dcf13ef18 (head)
+    dimensions-config: daf_butler 3 -> c5ae3a2cd7c2 (head)
+    opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager 0.2.0 -> 77e5b803ad3f (head)
 
 The output includes manager type name, its full class name (except for special ``dimensions-config`` manager), and its version number.
 The revision number appearing here is calculated from those three items and it must match one of the revisions in ``alembic_version`` table.

--- a/examples/SConscript
+++ b/examples/SConscript
@@ -1,3 +1,0 @@
-# -*- python -*-
-from lsst.sconsUtils import scripts
-scripts.BasicSConscript.examples()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest >= 3.2",
-    "flake8 >= 3.7.5",
-    "pytest-flake8 >= 1.0.4",
     "pytest-openfiles >= 0.5.0"
 ]
 
@@ -49,7 +47,7 @@ zip-safe = true
 license-files = ["COPYRIGHT", "LICENSE"]
 
 [tool.setuptools.package-data]
-"lsst.daf.butler_migrate" = []
+"lsst.daf.butler_migrate" = ["py.typed", "cli/resources.yaml"]
 
 [tool.setuptools.dynamic]
 version = { attr = "lsst_versions.get_lsst_version" }

--- a/python/lsst/daf/butler_migrate/scripts.py
+++ b/python/lsst/daf/butler_migrate/scripts.py
@@ -48,3 +48,14 @@ class Scripts:
             migration tree.
         """
         return list(self.scripts.get_bases())
+
+    def head_revisions(self) -> list[str]:
+        """Return list of all head revisions, or tops of the migration trees.
+
+        Returns
+        -------
+        heads : `list` [`str`]
+            Head revisions, corresponding to the tops of the each migration
+            tree.
+        """
+        return list(self.scripts.get_heads())


### PR DESCRIPTION
`show-current --butler` now shows `(head)` tag similarly to `show-current`,
this makes it easier to identify managers that need schema upgrade.