### PR TITLE
DM-50958: Add migration script for MonolithicDatastoreRegistryBridgeManager 0.2.1

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -7,5 +7,15 @@ on:
   pull_request:
 
 jobs:
-  call-workflow:
+
+  # Mypy does not like repeating file names, have to check _oneshot
+  # separately from everyhting else.
+  mypy-almost-all:
     uses: lsst/rubin_workflows/.github/workflows/mypy.yaml@main
+    with:
+      folders: "python tests migrations/_alembic migrations/[a-z]*"
+
+  mypy-oneshot:
+    uses: lsst/rubin_workflows/.github/workflows/mypy.yaml@main
+    with:
+      folders: "python migrations/_oneshot"

--- a/doc/changes/DM-50958.feature.md
+++ b/doc/changes/DM-50958.feature.md
@@ -1,0 +1,2 @@
+Added migration script for MonolithicDatastoreRegistryBridgeManager 0.2.1.
+This migration reverses the order of columns in PK of `dataset_location_trash` table.

--- a/doc/lsst.daf.butler_migrate/migrations/datastores.rst
+++ b/doc/lsst.daf.butler_migrate/migrations/datastores.rst
@@ -3,3 +3,10 @@ Migrations for datastores manager
 #################################
 
 The ``datastores`` tree has migrations defined for all manager versions that have existed in our code, but none of these migrations were actually implemented.
+
+MonolithicDatastoreRegistryBridgeManager 0.2.0 to 0.2.1
+=======================================================
+
+Migration script: `a81dddabd837.py <https://github.com/lsst-dm/daf_butler_migrate/blob/main/migrations/datastores/a81dddabd837.py>`_
+
+Reverses the order of columns in PK of ``dataset_location_trash`` table.

--- a/migrations/_alembic/env.py
+++ b/migrations/_alembic/env.py
@@ -27,7 +27,6 @@ def run_migrations_offline() -> None:
 
     Calls to context.execute() here emit the given string to the
     script output.
-
     """
     url = config.get_main_option("sqlalchemy.url")
     schema = config.get_section_option("daf_butler_migrate", "schema")
@@ -48,7 +47,6 @@ def run_migrations_online() -> None:
 
     In this scenario we need to create an Engine
     and associate a connection with the context.
-
     """
     config_dict = config.get_section(config.config_ini_section)
     assert config_dict is not None, "Expect non-empty configuration"

--- a/migrations/_alembic/script.py.mako
+++ b/migrations/_alembic/script.py.mako
@@ -1,12 +1,21 @@
 <%!
-def fmt(item):
-    if item is None:
-        return "None"
-    elif isinstance(item, (list, tuple)):
-        strings = [fmt(i) for i in item]
-        return f'({", ".join(strings)},)'
-    else:
+def dq(item):
+    if isinstance(item, str):
         return f'"{item}"'
+    elif isinstance(item, tuple):
+        r = ", ".join(dq(i) for i in item)
+        if len(item) == 1:
+            r += ","
+        return f"({r})"
+    elif isinstance(item, (list, tuple)):
+        r = ", ".join(dq(i) for i in item)
+        return f"[{r}]"
+    else:
+        return item
+%>\
+<%
+tree_name = config.attributes.get("tree_name", "")
+new_version = config.attributes.get("new_version", "")
 %>\
 """${message}
 
@@ -19,22 +28,50 @@ import logging
 
 import sqlalchemy as sa
 from alembic import op
+
+from lsst.daf.butler_migrate.migration_context import MigrationContext
 ${imports if imports else ""}
 # revision identifiers, used by Alembic.
-revision = ${up_revision | n,fmt}
-down_revision = ${down_revision | n,fmt}
-branch_labels = ${branch_labels | n,fmt}
-depends_on = ${depends_on | n,fmt}
+revision = ${dq(up_revision)}
+down_revision = ${dq(down_revision)}
+branch_labels = ${dq(branch_labels)}
+depends_on = ${dq(depends_on)}
 
 # Logger name should start with lsst to work with butler logging option.
 _LOG = logging.getLogger(f"lsst.{__name__}")
 
+% if tree_name != "dimensions-config":
+MANAGER_NAME = "Enter full manager class name here"
+NEW_VERSION = "${new_version}"
+OLD_VERSION = "Specify old version number here"
+% endif
+
 
 def upgrade() -> None:
-    """Perform schema upgrade."""
-    ${upgrades if upgrades else "raise NotImplementedError()"}
+    """Upgrade '...' tree from ... to ... (ticket ...).
+
+    Summary of changes:
+      - <Add summary of changes>.
+    """
+% if tree_name == "dimensions-config":
+    ctx = MigrationContext()
+    # Add code to upgrade the schema using `ctx` attributes.
+    raise NotImplementedError()
+% else:
+    with MigrationContext(MANAGER_NAME, NEW_VERSION) as ctx:  # noqa: F841
+        # Add code to downgrade the schema using `ctx` attributes.
+        raise NotImplementedError()
+% endif
 
 
 def downgrade() -> None:
-    """Perform schema downgrade."""
-    ${downgrades if downgrades else "raise NotImplementedError()"}
+    """Undo changes applied in `upgrade`."""
+% if tree_name == "dimensions-config":
+    ctx = MigrationContext()
+    # Add code to downgrade the schema using `ctx` attributes.
+    raise NotImplementedError()
+% else:
+    with MigrationContext(MANAGER_NAME, OLD_VERSION) as ctx:  # noqa: F841
+        # Add code to downgrade the schema using `ctx` attributes.
+        raise NotImplementedError()
+% endif

--- a/migrations/datastores/a81dddabd837.py
+++ b/migrations/datastores/a81dddabd837.py
@@ -1,0 +1,67 @@
+"""Migration script for MonolithicDatastoreRegistryBridgeManager 0.2.1.
+
+Revision ID: a81dddabd837
+Revises: a07b3b60e369
+Create Date: 2025-05-20 14:57:52.486966
+"""
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+from lsst.daf.butler_migrate.migration_context import MigrationContext
+
+# revision identifiers, used by Alembic.
+revision = "a81dddabd837"
+down_revision = "a07b3b60e369"
+branch_labels = None
+depends_on = None
+
+# Logger name should start with lsst to work with butler logging option.
+_LOG = logging.getLogger(f"lsst.{__name__}")
+
+MANAGER_NAME = "lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager"
+NEW_VERSION = "0.2.1"
+OLD_VERSION = "0.2.0"
+
+
+def upgrade() -> None:
+    """Upgrade 'datastores' tree from 0.2.0 to 0.2.1 (ticket DM-50958).
+
+    Summary of changes:
+
+        - Order of the columns in PK of ``dataset_location_trash`` table
+          is reversed.
+    """
+    with MigrationContext(MANAGER_NAME, NEW_VERSION) as ctx:
+        # Add code to downgrade the schema using `ctx` attributes.
+        _migrate(ctx, True)
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with MigrationContext(MANAGER_NAME, OLD_VERSION) as ctx:
+        # Add code to downgrade the schema using `ctx` attributes.
+        _migrate(ctx, False)
+
+
+def _migrate(ctx: MigrationContext, upgrade: bool) -> None:
+    """Upgrade or downgrade the schema.
+
+    Parameters
+    ----------
+    ctx : `MigrationContext`
+        Migration context.
+    upgrade : `bool`
+        Upgrade if `True`, downgrade if `False`.
+    """
+    pk_columns = ["dataset_id", "datastore_name"] if upgrade else ["datastore_name", "dataset_id"]
+    with op.batch_alter_table("dataset_location_trash", schema=ctx.schema) as batch_op:
+        # We need to recreate PK, and for Postgres we have to drop existing PK
+        # first.  In sqlite we do not even have name for PK constraint, so it
+        # cannot be dropped explicitly, but new one can be made anyways.
+        if not ctx.is_sqlite:
+            _LOG.info("Dropping existing primary key")
+            batch_op.drop_constraint("dataset_location_trash_pkey")
+        _LOG.info("Creating primary key with columns %s", pk_columns)
+        batch_op.create_primary_key("dataset_location_trash_pkey", pk_columns)

--- a/migrations/obscore-config/4fe28ef5030f.py
+++ b/migrations/obscore-config/4fe28ef5030f.py
@@ -139,7 +139,7 @@ def _read_obscore_config() -> dict:
 
 
 def _make_obscore_table(obscore_config: dict) -> None:
-    """Create obecore table.
+    """Create obscore table.
 
     Parameters
     ----------

--- a/migrations/obscore-config/4fe28ef5030f.py
+++ b/migrations/obscore-config/4fe28ef5030f.py
@@ -3,7 +3,6 @@
 Revision ID: 4fe28ef5030f
 Revises: 2daeabfb5019
 Create Date: 2023-02-02 10:28:46.217250
-
 """
 
 import json
@@ -71,7 +70,13 @@ def downgrade() -> None:
 
 
 def _migrate(obscore_config: dict | None) -> None:
-    """Upgrade or downgrade schema."""
+    """Upgrade or downgrade schema.
+
+    Parameters
+    ----------
+    obscore_config : `dict`
+        Obscore configuration.
+    """
 
     mig_context = context.get_context()
     schema = mig_context.version_table_schema
@@ -134,7 +139,13 @@ def _read_obscore_config() -> dict:
 
 
 def _make_obscore_table(obscore_config: dict) -> None:
-    """Create obecore table."""
+    """Create obecore table.
+
+    Parameters
+    ----------
+    obscore_config : `dict`
+        Obscore configuration.
+    """
 
     mig_context = context.get_context()
     schema = mig_context.version_table_schema
@@ -166,10 +177,11 @@ def _make_obscore_table(obscore_config: dict) -> None:
             config=obscore_config,
             datasets=managers.datasets.__class__,
             dimensions=managers.dimensions,
+            column_type_info=registry._managers.column_types,
         )
     # Note that we are using bind from migration context, and not from
     # Registry. This should work in general, but watch for any surprises.
     # Reflecting metadata is needed for foreign key in obscore table.
     assert database._metadata is not None
-    database._metadata.reflect(bind, schema=schema)
+    database._metadata._metadata.reflect(bind, schema=schema)
     manager.table.create(bind)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,4 +150,5 @@ checks = [
 exclude = [
     "^test_.*",  # Do not test docstrings in test code.
     '^commands\.',  # Click docstrings, not numpydoc
+    '\.__exit__',  # Do not check docstrings in context methods.
 ]

--- a/python/lsst/daf/butler_migrate/script/migrate_add_tree.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_add_tree.py
@@ -83,6 +83,8 @@ def migrate_add_tree(tree_name: str, mig_path: str, one_shot: bool) -> None:
         raise ValueError(f"Version tree {tree_name!r} already exists in {tree_folder}")
 
     cfg = config.MigAlembicConfig.from_mig_path(mig_path, single_tree=tree_name)
+    # Pass tree name to template.
+    cfg.attributes["tree_name"] = tree_name
 
     # may need to initialize the whole shebang
     alembic_folder = trees.alembic_folder(relative=False)

--- a/python/lsst/daf/butler_migrate/script/migrate_revision.py
+++ b/python/lsst/daf/butler_migrate/script/migrate_revision.py
@@ -92,6 +92,10 @@ def migrate_revision(mig_path: str, tree_name: str, manager_class: str, version:
     cfg = config.MigAlembicConfig.from_mig_path(mig_path)
     scripts = ScriptDirectory.from_config(cfg)
 
+    # Pass tree name to template.
+    cfg.attributes["tree_name"] = tree_name
+    cfg.attributes["new_version"] = version
+
     # make sure that tree root is defined
     root = revision.rev_id(tree_name)
     if not _revision_exists(scripts, root):
@@ -112,7 +116,10 @@ def migrate_revision(mig_path: str, tree_name: str, manager_class: str, version:
 
     # now can make actual revision
     rev_id = revision.rev_id(tree_name, manager_class, version)
-    message = f"Migration script for {manager_class} {version}."
+    if tree_name == "dimensions-config":
+        message = f"Migration script for dimensions.yaml namespace={manager_class} version={version}."
+    else:
+        message = f"Migration script for {manager_class} {version}."
     command.revision(
         cfg,
         head=head,
@@ -127,6 +134,10 @@ def migrate_revision(mig_path: str, tree_name: str, manager_class: str, version:
 def _migrate_revision_one_shot(mig_path: str, tree_name: str, manager_class: str, version: str) -> None:
     cfg = config.MigAlembicConfig.from_mig_path(mig_path, single_tree=tree_name)
     scripts = ScriptDirectory.from_config(cfg)
+
+    # Pass tree name to template.
+    cfg.attributes["tree_name"] = tree_name
+    cfg.attributes["new_version"] = version
 
     # We want to keep trees in separate directories
     migrate_trees = migrate.MigrationTrees(mig_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click >7.0
 sqlalchemy
-alembic
+alembic != 1.15.2
+testing.postgresql
 lsst-resources @ git+https://github.com/lsst/resources@main
 lsst-utils @ git+https://github.com/lsst/utils@main
 lsst-daf-butler @ git+https://github.com/lsst/daf_butler@main

--- a/templates/generic/script.py.mako
+++ b/templates/generic/script.py.mako
@@ -1,12 +1,21 @@
 <%!
-def fmt(item):
-    if item is None:
-        return "None"
-    elif isinstance(item, (list, tuple)):
-        strings = [fmt(i) for i in item]
-        return f'({", ".join(strings)},)'
-    else:
+def dq(item):
+    if isinstance(item, str):
         return f'"{item}"'
+    elif isinstance(item, tuple):
+        r = ", ".join(dq(i) for i in item)
+        if len(item) == 1:
+            r += ","
+        return f"({r})"
+    elif isinstance(item, (list, tuple)):
+        r = ", ".join(dq(i) for i in item)
+        return f"[{r}]"
+    else:
+        return item
+%>\
+<%
+tree_name = config.attributes.get("tree_name", "")
+new_version = config.attributes.get("new_version", "")
 %>\
 """${message}
 
@@ -19,22 +28,50 @@ import logging
 
 import sqlalchemy as sa
 from alembic import op
+
+from lsst.daf.butler_migrate.migration_context import MigrationContext
 ${imports if imports else ""}
 # revision identifiers, used by Alembic.
-revision = ${up_revision | n,fmt}
-down_revision = ${down_revision | n,fmt}
-branch_labels = ${branch_labels | n,fmt}
-depends_on = ${depends_on | n,fmt}
+revision = ${dq(up_revision)}
+down_revision = ${dq(down_revision)}
+branch_labels = ${dq(branch_labels)}
+depends_on = ${dq(depends_on)}
 
 # Logger name should start with lsst to work with butler logging option.
 _LOG = logging.getLogger(f"lsst.{__name__}")
 
+% if tree_name != "dimensions-config":
+MANAGER_NAME = "Enter full manager class name here"
+NEW_VERSION = "${new_version}"
+OLD_VERSION = "Specify old version number here"
+% endif
+
 
 def upgrade() -> None:
-    """Perform schema upgrade."""
-    ${upgrades if upgrades else "raise NotImplementedError()"}
+    """Upgrade '...' tree from ... to ... (ticket ...).
+
+    Summary of changes:
+      - <Add summary of changes>.
+    """
+% if tree_name == "dimensions-config":
+    ctx = MigrationContext()
+    # Add code to upgrade the schema using `ctx` attributes.
+    raise NotImplementedError()
+% else:
+    with MigrationContext(MANAGER_NAME, NEW_VERSION) as ctx:  # noqa: F841
+        # Add code to downgrade the schema using `ctx` attributes.
+        raise NotImplementedError()
+% endif
 
 
 def downgrade() -> None:
-    """Perform schema downgrade."""
-    ${downgrades if downgrades else "raise NotImplementedError()"}
+    """Undo changes applied in `upgrade`."""
+% if tree_name == "dimensions-config":
+    ctx = MigrationContext()
+    # Add code to downgrade the schema using `ctx` attributes.
+    raise NotImplementedError()
+% else:
+    with MigrationContext(MANAGER_NAME, OLD_VERSION) as ctx:  # noqa: F841
+        # Add code to downgrade the schema using `ctx` attributes.
+        raise NotImplementedError()
+% endif


### PR DESCRIPTION
Also few improvements to reduce code duplication (but old scripts were not updated yet), and fixes for mypy-discovered issues with old migration scripts.

## Checklist

- [X] added documentation for a new migration script
- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
