### PR TITLE
DM-53233: Fix ObsCore migration

### DIFF
--- a/migrations/obscore-config/4fe28ef5030f.py
+++ b/migrations/obscore-config/4fe28ef5030f.py
@@ -177,7 +177,6 @@ def _make_obscore_table(obscore_config: dict) -> None:
             config=obscore_config,
             datasets=managers.datasets.__class__,
             dimensions=managers.dimensions,
-            column_type_info=registry._managers.column_types,
         )
     # Note that we are using bind from migration context, and not from
     # Registry. This should work in general, but watch for any surprises.


### PR DESCRIPTION
Remove a parameter to the `ObsCoreLiveTableManager` constructor which is no longer needed and no longer exists.

## Checklist

- [ ] added documentation for a new migration script
- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
